### PR TITLE
Discord button link on homepage now opens in a new tab.

### DIFF
--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -13,6 +13,7 @@
       <div class="home__landing__content__button">
         <div class="home__landing__content__button__front">
           <a
+            target="_blank"
             class="home__landing__content__button__front__text"
             href="http://bit.ly/acm-ucm-discord"
             >Discord</a


### PR DESCRIPTION
Added target attribute to "a" tag for discord link in home page.