### PR TITLE
enh/home page navbar correction

### DIFF
--- a/src/app/pages/home/home.component.scss
+++ b/src/app/pages/home/home.component.scss
@@ -5,6 +5,7 @@ $animation-duration: infinite;
   background-color: var(--background);
   width: 100%;
   height: auto;
+  margin-top: 45px;
 
   &__landing {
     background-color: var(--landing-background);


### PR DESCRIPTION
I'm not sure if this was intentional, but there was some extra margins in the navbar from the .home class in the home page, so I got rid of the extra margin on the navbar. Please close this pr if that was intentional.