### PR TITLE
Fix incorrect usage of pre-commit hooks installation

### DIFF
--- a/docs/onboarding/introduction.rst
+++ b/docs/onboarding/introduction.rst
@@ -60,7 +60,7 @@ that forked the base repo)
 .. code:: bash
 
   npm install \
-  && npm run setup-pch
+  && npm run prepare
 
 3. Copy the ``.env.example`` file to ``.env`` and modify in the appropriate values
 

--- a/react/ucmacm-website/.husky/pre-commit
+++ b/react/ucmacm-website/.husky/pre-commit
@@ -2,5 +2,5 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 cd react/ucmacm-website
-yarn run lint
-yarn run format
+npm run lint
+npm run format


### PR DESCRIPTION
# Summary

This PR addresses the incorrect usage of installing pre-commit hooks using Husky. It was previously noted to be `npm run setup-pch` but due to how `npm` hooks work, it now uses `npm run prepare`. In addition, the pre-commit hooks now use npm instead of yarn as some folks may have issues using yarn on Windows and the installation process.

## Types of changes

What types of changes does your code introduce to the UC Merced's ACM Chapter Website?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] Lint, format, and unit test workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR

