### PR TITLE
Fix Husky deprecation

### DIFF
--- a/react/ucmacm-website/.husky/pre-commit
+++ b/react/ucmacm-website/.husky/pre-commit
@@ -1,2 +1,0 @@
-npm run lint
-npm run format

--- a/react/ucmacm-website/package.json
+++ b/react/ucmacm-website/package.json
@@ -7,11 +7,10 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "prepare": "cd ../../ && husky init",
+    "prepare": "cd ../../ && husky react/ucmacm-website/.husky",
     "preview": "vite preview",
     "check": "prettier . --check",
-    "format": "prettier . --write",
-    "prepare": "husky"
+    "format": "prettier . --write"
   },
   "dependencies": {
     "@icons-pack/react-simple-icons": "^9.4.1",


### PR DESCRIPTION
# Summary

This PR aims to fix the deprecation errors found in Husky when migrating from v8 to v9.

FYI in order to use this, just reinstall your node modules (aka `npm install`) again and it should hook on properly now

## Types of changes

What types of changes does your code introduce to the UC Merced's ACM Chapter Website?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] Lint, format, and unit test workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR

