### PR TITLE
Automatically install Lefthook during setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Make sure you have the following:
 
 - [Node.js 22](https://nodejs.org/en/download/)
 
-Run `npm install && lefthook install`, then `npm run dev`.
+Run `npm install`, then `npm run dev`.
 
 A more in-depth introduction (recommended to read) can be found [here](https://ucmacm-docs.netlify.app)
 

--- a/react/package.json
+++ b/react/package.json
@@ -7,7 +7,8 @@
 		"dev": "vite",
 		"build": "tsc && vite build",
 		"preview": "vite preview",
-		"check": "biome check --write src"
+		"check": "biome check --write src",
+		"prepare": "lefthook install"
 	},
 	"dependencies": {
 		"@icons-pack/react-simple-icons": ">=10.0 <11",


### PR DESCRIPTION
# Summary

To make life easier, instead of running the `lefthook install` command after you install the npm deps, we just do it inside of an script right after installation. This also prevents me from reminding folks to do that constantly. Kinda of a neat and handy trick tbh.

## Types of changes

What types of changes does your code introduce to the UC Merced's ACM Chapter Website?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] Lint, format, and unit test workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR

