### PR TITLE
Update `@nextui-org/react` to 2.6.10 in order to avoid peer dependency issues

### DIFF
--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.0.0",
 			"dependencies": {
 				"@icons-pack/react-simple-icons": "^10.2.0",
-				"@nextui-org/react": "^2.6.8",
+				"@nextui-org/react": "^2.6.10",
 				"framer-motion": "^11.14.4",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
@@ -32,8 +32,6 @@
 		},
 		"node_modules/@alloc/quick-lru": {
 			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
-			"integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
@@ -56,8 +54,6 @@
 		},
 		"node_modules/@biomejs/biome": {
 			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
-			"integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT OR Apache-2.0",
@@ -82,78 +78,8 @@
 				"@biomejs/cli-win32-x64": "1.9.4"
 			}
 		},
-		"node_modules/@biomejs/cli-darwin-arm64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
-			"integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
-		"node_modules/@biomejs/cli-darwin-x64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
-			"integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
-		"node_modules/@biomejs/cli-linux-arm64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
-			"integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
-		"node_modules/@biomejs/cli-linux-arm64-musl": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
-			"integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
 		"node_modules/@biomejs/cli-linux-x64": {
 			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
-			"integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
 			"cpu": [
 				"x64"
 			],
@@ -169,8 +95,6 @@
 		},
 		"node_modules/@biomejs/cli-linux-x64-musl": {
 			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
-			"integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
 			"cpu": [
 				"x64"
 			],
@@ -182,318 +106,10 @@
 			],
 			"engines": {
 				"node": ">=14.21.3"
-			}
-		},
-		"node_modules/@biomejs/cli-win32-arm64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
-			"integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
-		"node_modules/@biomejs/cli-win32-x64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
-			"integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
-		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.0.tgz",
-			"integrity": "sha512-WtKdFM7ls47zkKHFVzMz8opM7LkcsIp9amDUBIAWirg70RM71WRSjdILPsY5Uv1D42ZpUfaPILDlfactHgsRkw==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"aix"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/android-arm": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.0.tgz",
-			"integrity": "sha512-arAtTPo76fJ/ICkXWetLCc9EwEHKaeya4vMrReVlEIUCAUncH7M4bhMQ+M9Vf+FFOZJdTNMXNBrWwW+OXWpSew==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/android-arm64": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.0.tgz",
-			"integrity": "sha512-Vsm497xFM7tTIPYK9bNTYJyF/lsP590Qc1WxJdlB6ljCbdZKU9SY8i7+Iin4kyhV/KV5J2rOKsBQbB77Ab7L/w==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/android-x64": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.0.tgz",
-			"integrity": "sha512-t8GrvnFkiIY7pa7mMgJd7p8p8qqYIz1NYiAoKc75Zyv73L3DZW++oYMSHPRarcotTKuSs6m3hTOa5CKHaS02TQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.0.tgz",
-			"integrity": "sha512-CKyDpRbK1hXwv79soeTJNHb5EiG6ct3efd/FTPdzOWdbZZfGhpbcqIpiD0+vwmpu0wTIL97ZRPZu8vUt46nBSw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.0.tgz",
-			"integrity": "sha512-rgtz6flkVkh58od4PwTRqxbKH9cOjaXCMZgWD905JOzjFKW+7EiUObfd/Kav+A6Gyud6WZk9w+xu6QLytdi2OA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.0.tgz",
-			"integrity": "sha512-6Mtdq5nHggwfDNLAHkPlyLBpE5L6hwsuXZX8XNmHno9JuL2+bg2BX5tRkwjyfn6sKbxZTq68suOjgWqCicvPXA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.0.tgz",
-			"integrity": "sha512-D3H+xh3/zphoX8ck4S2RxKR6gHlHDXXzOf6f/9dbFt/NRBDIE33+cVa49Kil4WUjxMGW0ZIYBYtaGCa2+OsQwQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-arm": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.0.tgz",
-			"integrity": "sha512-gJKIi2IjRo5G6Glxb8d3DzYXlxdEj2NlkixPsqePSZMhLudqPhtZ4BUrpIuTjJYXxvF9njql+vRjB2oaC9XpBw==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.0.tgz",
-			"integrity": "sha512-TDijPXTOeE3eaMkRYpcy3LarIg13dS9wWHRdwYRnzlwlA370rNdZqbcp0WTyyV/k2zSxfko52+C7jU5F9Tfj1g==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.0.tgz",
-			"integrity": "sha512-K40ip1LAcA0byL05TbCQ4yJ4swvnbzHscRmUilrmP9Am7//0UjPreh4lpYzvThT2Quw66MhjG//20mrufm40mA==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.0.tgz",
-			"integrity": "sha512-0mswrYP/9ai+CU0BzBfPMZ8RVm3RGAN/lmOMgW4aFUSOQBjA31UP8Mr6DDhWSuMwj7jaWOT0p0WoZ6jeHhrD7g==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.0.tgz",
-			"integrity": "sha512-hIKvXm0/3w/5+RDtCJeXqMZGkI2s4oMUGj3/jM0QzhgIASWrGO5/RlzAzm5nNh/awHE0A19h/CvHQe6FaBNrRA==",
-			"cpu": [
-				"mips64el"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.0.tgz",
-			"integrity": "sha512-HcZh5BNq0aC52UoocJxaKORfFODWXZxtBaaZNuN3PUX3MoDsChsZqopzi5UupRhPHSEHotoiptqikjN/B77mYQ==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.0.tgz",
-			"integrity": "sha512-bEh7dMn/h3QxeR2KTy1DUszQjUrIHPZKyO6aN1X4BCnhfYhuQqedHaa5MxSQA/06j3GpiIlFGSsy1c7Gf9padw==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.0.tgz",
-			"integrity": "sha512-ZcQ6+qRkw1UcZGPyrCiHHkmBaj9SiCD8Oqd556HldP+QlpUIe2Wgn3ehQGVoPOvZvtHm8HPx+bH20c9pvbkX3g==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
 			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.0.tgz",
-			"integrity": "sha512-vbutsFqQ+foy3wSSbmjBXXIJ6PL3scghJoM8zCL142cGaZKAdCZHyf+Bpu/MmX9zT9Q0zFBVKb36Ma5Fzfa8xA==",
 			"cpu": [
 				"x64"
 			],
@@ -502,125 +118,6 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.0.tgz",
-			"integrity": "sha512-hjQ0R/ulkO8fCYFsG0FZoH+pWgTTDreqpqY7UnQntnaKv95uP5iW3+dChxnx7C3trQQU40S+OgWhUVwCjVFLvg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.0.tgz",
-			"integrity": "sha512-MD9uzzkPQbYehwcN583yx3Tu5M8EIoTD+tUgKF982WYL9Pf5rKy9ltgD0eUgs8pvKnmizxjXZyLt0z6DC3rRXg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.0.tgz",
-			"integrity": "sha512-4ir0aY1NGUhIC1hdoCzr1+5b43mw99uNwVzhIq1OY3QcEwPDO3B7WNXBzaKY5Nsf1+N11i1eOfFcq+D/gOS15Q==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.0.tgz",
-			"integrity": "sha512-jVzdzsbM5xrotH+W5f1s+JtUy1UWgjU0Cf4wMvffTB8m6wP5/kx0KiaLHlbJO+dMgtxKV8RQ/JvtlFcdZ1zCPA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"sunos"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.0.tgz",
-			"integrity": "sha512-iKc8GAslzRpBytO2/aN3d2yb2z8XTVfNV0PjGlCxKo5SgWmNXx82I/Q3aG1tFfS+A2igVCY97TJ8tnYwpUWLCA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.0.tgz",
-			"integrity": "sha512-vQW36KZolfIudCcTnaTpmLQ24Ha1RjygBo39/aLkM2kmjkWmZGEJ5Gn9l5/7tzXA42QGIoWbICfg6KLLkIw6yw==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/win32-x64": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.0.tgz",
-			"integrity": "sha512-7IAFPrjSQIJrGsK6flwg7NFmwBoSTyF3rl7If0hNUFQU4ilTsEPL6GuMuU9BfIWVVGuRnuIidkSMC+c0Otu8IA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
 			],
 			"engines": {
 				"node": ">=18"
@@ -679,8 +176,6 @@
 		},
 		"node_modules/@icons-pack/react-simple-icons": {
 			"version": "10.2.0",
-			"resolved": "https://registry.npmjs.org/@icons-pack/react-simple-icons/-/react-simple-icons-10.2.0.tgz",
-			"integrity": "sha512-QDUxup8D3GdIIzwGpxQs6bjeFV5mJes25qqf4aqP/PaBYQNCar7AiyD8C14636TosCG0A/QqAUwm/Hviep4d4g==",
 			"license": "MIT",
 			"peerDependencies": {
 				"react": "^16.13 || ^17 || ^18 || ^19"
@@ -725,8 +220,6 @@
 		},
 		"node_modules/@isaacs/cliui": {
 			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
 			"license": "ISC",
 			"dependencies": {
 				"string-width": "^5.1.2",
@@ -742,8 +235,6 @@
 		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.3.8",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
-			"integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/set-array": "^1.2.1",
@@ -756,8 +247,6 @@
 		},
 		"node_modules/@jridgewell/resolve-uri": {
 			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.0.0"
@@ -765,8 +254,6 @@
 		},
 		"node_modules/@jridgewell/set-array": {
 			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.0.0"
@@ -774,14 +261,10 @@
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-			"integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
 			"license": "MIT"
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.25",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
@@ -789,18 +272,18 @@
 			}
 		},
 		"node_modules/@nextui-org/accordion": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/@nextui-org/accordion/-/accordion-2.2.5.tgz",
-			"integrity": "sha512-u7OXe6W+4JO1REbfC/zyO2B0/bGav6GL17VJa1qp8lT6uQMt3Cn7+vUe28XpIkeTnJv+WMkzWYs2+V/moYq1oQ==",
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/@nextui-org/accordion/-/accordion-2.2.6.tgz",
+			"integrity": "sha512-injM1MJDdAxQ2TWHRXWM8aM2fELwsdQuvWSz4QINMMauS6qgWxWVF1OqxTd0FxSAAOyMuJIdm45p2K6eV9Ocsw==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/aria-utils": "2.2.5",
-				"@nextui-org/divider": "2.2.4",
+				"@nextui-org/aria-utils": "2.2.6",
+				"@nextui-org/divider": "2.2.5",
 				"@nextui-org/dom-animation": "2.1.1",
-				"@nextui-org/framer-utils": "2.1.4",
-				"@nextui-org/react-utils": "2.1.1",
+				"@nextui-org/framer-utils": "2.1.5",
+				"@nextui-org/react-utils": "2.1.2",
 				"@nextui-org/shared-icons": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
+				"@nextui-org/shared-utils": "2.1.2",
 				"@nextui-org/use-aria-accordion": "2.2.2",
 				"@react-aria/button": "3.11.0",
 				"@react-aria/focus": "3.19.0",
@@ -819,15 +302,15 @@
 			}
 		},
 		"node_modules/@nextui-org/alert": {
-			"version": "2.2.7",
-			"resolved": "https://registry.npmjs.org/@nextui-org/alert/-/alert-2.2.7.tgz",
-			"integrity": "sha512-HOIroKCa3z6hE58lAgF+JS8vsNFblOXcuMJwB+92t19q+jkoDCgo7pkPVqi4Hm4MRY2GpUQp+iAGZklA2P4n4Q==",
+			"version": "2.2.8",
+			"resolved": "https://registry.npmjs.org/@nextui-org/alert/-/alert-2.2.8.tgz",
+			"integrity": "sha512-2UzofZNowJCnRge98Qjj3+G586d2xXMEqyfJasNc2xXrejMmqNwnFC5vn1qNi+vzqnqOr75kTfQHtyRRLWEwhQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/button": "2.2.7",
-				"@nextui-org/react-utils": "2.1.1",
+				"@nextui-org/button": "2.2.8",
+				"@nextui-org/react-utils": "2.1.2",
 				"@nextui-org/shared-icons": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
+				"@nextui-org/shared-utils": "2.1.2",
 				"@react-aria/utils": "3.26.0",
 				"@react-stately/utils": "3.10.5"
 			},
@@ -839,14 +322,14 @@
 			}
 		},
 		"node_modules/@nextui-org/aria-utils": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/@nextui-org/aria-utils/-/aria-utils-2.2.5.tgz",
-			"integrity": "sha512-qSGp4butMjO4HhTuoHun33DEV7d5+rayJzKo9IOeDWdA7o65QQ7Gcjoz0pVgw8SQe5CBMURoUIHQA66NHB7v2Q==",
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/@nextui-org/aria-utils/-/aria-utils-2.2.6.tgz",
+			"integrity": "sha512-HrMLt8k1cYhHUDFg9D+DC71Dd9tZwhJkfseRjnOrccMF8f4eNV+olEfTp0+15lmdDXi6Xa1gXN5H4ZozKrNcug==",
 			"license": "MIT",
 			"dependencies": {
 				"@nextui-org/react-rsc-utils": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
-				"@nextui-org/system": "2.4.4",
+				"@nextui-org/shared-utils": "2.1.2",
+				"@nextui-org/system": "2.4.5",
 				"@react-aria/utils": "3.26.0",
 				"@react-stately/collections": "3.12.0",
 				"@react-stately/overlays": "3.6.12",
@@ -859,23 +342,23 @@
 			}
 		},
 		"node_modules/@nextui-org/autocomplete": {
-			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/@nextui-org/autocomplete/-/autocomplete-2.3.7.tgz",
-			"integrity": "sha512-bfGM59cKgDQCkKS9TR5zGD3aMNiHD1jLDh9uUciW0ij51CoqRBgvinIjOgocwHDJ0y5GbvijNK9djfYV9RYpSg==",
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/@nextui-org/autocomplete/-/autocomplete-2.3.8.tgz",
+			"integrity": "sha512-N7fRp5aAKi9hHX+ApqKfsZ3obOsizrRB2DZcbOrw2LgDjucsb3btyl8Zqi4oY4ZGSEn1DdCkbGylKPrgHTZ23Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/aria-utils": "2.2.5",
-				"@nextui-org/button": "2.2.7",
-				"@nextui-org/form": "2.1.6",
-				"@nextui-org/input": "2.4.6",
-				"@nextui-org/listbox": "2.3.7",
-				"@nextui-org/popover": "2.3.7",
-				"@nextui-org/react-utils": "2.1.1",
-				"@nextui-org/scroll-shadow": "2.3.3",
+				"@nextui-org/aria-utils": "2.2.6",
+				"@nextui-org/button": "2.2.8",
+				"@nextui-org/form": "2.1.7",
+				"@nextui-org/input": "2.4.7",
+				"@nextui-org/listbox": "2.3.8",
+				"@nextui-org/popover": "2.3.8",
+				"@nextui-org/react-utils": "2.1.2",
+				"@nextui-org/scroll-shadow": "2.3.4",
 				"@nextui-org/shared-icons": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
-				"@nextui-org/spinner": "2.2.4",
-				"@nextui-org/use-aria-button": "2.2.3",
+				"@nextui-org/shared-utils": "2.1.2",
+				"@nextui-org/spinner": "2.2.5",
+				"@nextui-org/use-aria-button": "2.2.4",
 				"@nextui-org/use-safe-layout-effect": "2.1.1",
 				"@react-aria/combobox": "3.11.0",
 				"@react-aria/focus": "3.19.0",
@@ -896,13 +379,13 @@
 			}
 		},
 		"node_modules/@nextui-org/avatar": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/@nextui-org/avatar/-/avatar-2.2.4.tgz",
-			"integrity": "sha512-YXEStFlK0/tMK31vzdEMvIYfUUGpHqqmwY1HA17dfKw0iL5UWMWK2lqN+QvBzfQfPTtbvDPW0ZcmyjOYHzx7Aw==",
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/@nextui-org/avatar/-/avatar-2.2.5.tgz",
+			"integrity": "sha512-ugpwuH1M+eyWY+6Fb4OgGev1HweRrE61bA3rHxRzR3CcjWoe9g7JoQ04NbNNLUDp+aZuil/RWmgSfGUXEexZVQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/react-utils": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
+				"@nextui-org/react-utils": "2.1.2",
+				"@nextui-org/shared-utils": "2.1.2",
 				"@nextui-org/use-image": "2.1.1",
 				"@react-aria/focus": "3.19.0",
 				"@react-aria/interactions": "3.22.5",
@@ -916,13 +399,13 @@
 			}
 		},
 		"node_modules/@nextui-org/badge": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/@nextui-org/badge/-/badge-2.2.3.tgz",
-			"integrity": "sha512-Q1OYR3Kt1VReo/vmNESXea/sIgdQTTav4PgHfESAk6PD9UkBNmT8Xbil1E2glAbglSU3WpqL/uOKEpQANpHVzw==",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/@nextui-org/badge/-/badge-2.2.4.tgz",
+			"integrity": "sha512-5Ac/ZpVFO8BFKzCbytu8NOCFQ4in9/BlP0qMUaPzqTJWJUNZljWyowSUI2BnFhnCG0hI4t1KTOxBpp0XDD/FGQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/react-utils": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1"
+				"@nextui-org/react-utils": "2.1.2",
+				"@nextui-org/shared-utils": "2.1.2"
 			},
 			"peerDependencies": {
 				"@nextui-org/system": ">=2.4.0",
@@ -932,14 +415,14 @@
 			}
 		},
 		"node_modules/@nextui-org/breadcrumbs": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/@nextui-org/breadcrumbs/-/breadcrumbs-2.2.4.tgz",
-			"integrity": "sha512-C+UyoYt1VFosD3leOrU1C3EsauUmjg+ZJEDCsO8WOlxvo2McEx0jqz9VmAqHCWrsIkPyZGxLfaiuhU8+T2AA6Q==",
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/@nextui-org/breadcrumbs/-/breadcrumbs-2.2.5.tgz",
+			"integrity": "sha512-hNhObcXlBu3itLdkZ70f/ZiKZt8VI+neolZFf9Ay7zs0p0fQKmNsDcd1Bj38DT652k+OYi/vALpR8f3Fa9WQsA==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/react-utils": "2.1.1",
+				"@nextui-org/react-utils": "2.1.2",
 				"@nextui-org/shared-icons": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
+				"@nextui-org/shared-utils": "2.1.2",
 				"@react-aria/breadcrumbs": "3.5.19",
 				"@react-aria/focus": "3.19.0",
 				"@react-aria/utils": "3.26.0",
@@ -954,16 +437,16 @@
 			}
 		},
 		"node_modules/@nextui-org/button": {
-			"version": "2.2.7",
-			"resolved": "https://registry.npmjs.org/@nextui-org/button/-/button-2.2.7.tgz",
-			"integrity": "sha512-3o7uAD7nFAUKJkg2PZ5ktJR8qqMrjQgzewXBWfz62RWya/uTFXzqwljy0JYGwq3tfvbmBzA1GGsAZdj5wUEymw==",
+			"version": "2.2.8",
+			"resolved": "https://registry.npmjs.org/@nextui-org/button/-/button-2.2.8.tgz",
+			"integrity": "sha512-Km9ER+jpA3DdYmbh8k30w2DMXZIPtZjs7QVVaPAEW+rJYnGWNsomcltlOLIvHpBYeAbB8hfJCbRJ35r9WeL9Gw==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/react-utils": "2.1.1",
-				"@nextui-org/ripple": "2.2.5",
-				"@nextui-org/shared-utils": "2.1.1",
-				"@nextui-org/spinner": "2.2.4",
-				"@nextui-org/use-aria-button": "2.2.3",
+				"@nextui-org/react-utils": "2.1.2",
+				"@nextui-org/ripple": "2.2.6",
+				"@nextui-org/shared-utils": "2.1.2",
+				"@nextui-org/spinner": "2.2.5",
+				"@nextui-org/use-aria-button": "2.2.4",
 				"@react-aria/button": "3.11.0",
 				"@react-aria/focus": "3.19.0",
 				"@react-aria/interactions": "3.22.5",
@@ -980,19 +463,19 @@
 			}
 		},
 		"node_modules/@nextui-org/calendar": {
-			"version": "2.2.7",
-			"resolved": "https://registry.npmjs.org/@nextui-org/calendar/-/calendar-2.2.7.tgz",
-			"integrity": "sha512-eZ4rmBFqJjmqg0n9F0QlfdfKQgZi4Z63kY0j6NCJ0f7fVtV61GHLNoZjVaaL1HDaMgcH3B7hVUvKtQOgKyzpkw==",
+			"version": "2.2.8",
+			"resolved": "https://registry.npmjs.org/@nextui-org/calendar/-/calendar-2.2.8.tgz",
+			"integrity": "sha512-Bt1Nl2mwBhFD4cBBBLtZkSmry9VZGnBl/7CV84tojrJsLUV5268wp/S6w4sQb5q4uGEO7qF+eZx6w5E6OHrcVQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@internationalized/date": "3.6.0",
-				"@nextui-org/button": "2.2.7",
+				"@nextui-org/button": "2.2.8",
 				"@nextui-org/dom-animation": "2.1.1",
-				"@nextui-org/framer-utils": "2.1.4",
-				"@nextui-org/react-utils": "2.1.1",
+				"@nextui-org/framer-utils": "2.1.5",
+				"@nextui-org/react-utils": "2.1.2",
 				"@nextui-org/shared-icons": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
-				"@nextui-org/use-aria-button": "2.2.3",
+				"@nextui-org/shared-utils": "2.1.2",
+				"@nextui-org/use-aria-button": "2.2.4",
 				"@react-aria/calendar": "3.6.0",
 				"@react-aria/focus": "3.19.0",
 				"@react-aria/i18n": "3.12.4",
@@ -1016,15 +499,15 @@
 			}
 		},
 		"node_modules/@nextui-org/card": {
-			"version": "2.2.7",
-			"resolved": "https://registry.npmjs.org/@nextui-org/card/-/card-2.2.7.tgz",
-			"integrity": "sha512-66GB3+Zw6T1LD2JVMSypSvp8zeiWxb7r+00SmRdN13vf5twUepC1HkfRGOLs0yTqjiSRBSnA0veXl9z23dszbw==",
+			"version": "2.2.8",
+			"resolved": "https://registry.npmjs.org/@nextui-org/card/-/card-2.2.8.tgz",
+			"integrity": "sha512-EOEVw7mao1dnwGaeoSwBwF1bEL3JirMR0C/EVot427eV8GmWOliBM+kEdD6NLloFMbK4NKHO+Mg8kYTTtGBowA==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/react-utils": "2.1.1",
-				"@nextui-org/ripple": "2.2.5",
-				"@nextui-org/shared-utils": "2.1.1",
-				"@nextui-org/use-aria-button": "2.2.3",
+				"@nextui-org/react-utils": "2.1.2",
+				"@nextui-org/ripple": "2.2.6",
+				"@nextui-org/shared-utils": "2.1.2",
+				"@nextui-org/use-aria-button": "2.2.4",
 				"@react-aria/button": "3.11.0",
 				"@react-aria/focus": "3.19.0",
 				"@react-aria/interactions": "3.22.5",
@@ -1040,14 +523,14 @@
 			}
 		},
 		"node_modules/@nextui-org/checkbox": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/@nextui-org/checkbox/-/checkbox-2.3.6.tgz",
-			"integrity": "sha512-QiJuRNllmRACf2rDrA6/hT8o46PjC3P6ttzJxz1OeUH6ME8MUY+EyH0S+C4C+cWoBv4UC2JS5S5QXalQ0WSViw==",
+			"version": "2.3.7",
+			"resolved": "https://registry.npmjs.org/@nextui-org/checkbox/-/checkbox-2.3.7.tgz",
+			"integrity": "sha512-JTYvBQfAO7AKEEIdfWJ/SU0SiHDnay15lMZytxzLcbFr5kkFUCaFbNWrFmz3OQQTsHFqML1Hbd9cqUeMvdP/Fg==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/form": "2.1.6",
-				"@nextui-org/react-utils": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
+				"@nextui-org/form": "2.1.7",
+				"@nextui-org/react-utils": "2.1.2",
+				"@nextui-org/shared-utils": "2.1.2",
 				"@nextui-org/use-callback-ref": "2.1.1",
 				"@nextui-org/use-safe-layout-effect": "2.1.1",
 				"@react-aria/checkbox": "3.15.0",
@@ -1062,20 +545,20 @@
 			},
 			"peerDependencies": {
 				"@nextui-org/system": ">=2.4.0",
-				"@nextui-org/theme": ">=2.4.0",
+				"@nextui-org/theme": ">=2.4.3",
 				"react": ">=18 || >=19.0.0-rc.0",
 				"react-dom": ">=18 || >=19.0.0-rc.0"
 			}
 		},
 		"node_modules/@nextui-org/chip": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/@nextui-org/chip/-/chip-2.2.4.tgz",
-			"integrity": "sha512-7fii39lPei8o/3TwdmB8e8W/ZS0FdsQxSHQKXDQpB4meS3Q7CC9dxV1MtwiniE3SXOnSQY7ChvGmu6wkGRFOOA==",
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/@nextui-org/chip/-/chip-2.2.5.tgz",
+			"integrity": "sha512-AfXF40oLmi15X6z1kSwLSnxKixG2KR5TUXpu4xuLED2ub1me9mjiiPYCn2bo5nlu2lgGd93XSdCyyx6kQKQECA==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/react-utils": "2.1.1",
+				"@nextui-org/react-utils": "2.1.2",
 				"@nextui-org/shared-icons": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
+				"@nextui-org/shared-utils": "2.1.2",
 				"@react-aria/focus": "3.19.0",
 				"@react-aria/interactions": "3.22.5",
 				"@react-aria/utils": "3.26.0",
@@ -1089,14 +572,14 @@
 			}
 		},
 		"node_modules/@nextui-org/code": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/@nextui-org/code/-/code-2.2.4.tgz",
-			"integrity": "sha512-p39bvfI/8sPbau5v+JHZG4CVirVeXCrHXm25qpbwPhgm2TxcuPftuoJb5JQNF4x0j0ONLaHnz7Ilr/Ai2vo12w==",
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/@nextui-org/code/-/code-2.2.5.tgz",
+			"integrity": "sha512-o/LdXzayZeLKKQUZDF2a0RWgA3D7PdR/zVGzA/eQ74a4bJZ7FqYgsarIBQ6O8s+LtOsI3Z9CSLoTIspI/F+3Pw==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/react-utils": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
-				"@nextui-org/system-rsc": "2.3.4"
+				"@nextui-org/react-utils": "2.1.2",
+				"@nextui-org/shared-utils": "2.1.2",
+				"@nextui-org/system-rsc": "2.3.5"
 			},
 			"peerDependencies": {
 				"@nextui-org/theme": ">=2.4.0",
@@ -1105,15 +588,15 @@
 			}
 		},
 		"node_modules/@nextui-org/date-input": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/@nextui-org/date-input/-/date-input-2.3.6.tgz",
-			"integrity": "sha512-xLgDXAtyrgX1LbGOw3egKV2armcNeNQAnsdycTjy5nxDkcU6PqtJ7G3Oe28/MW7l0qTxUT7/JNnrbKCtxiap/w==",
+			"version": "2.3.7",
+			"resolved": "https://registry.npmjs.org/@nextui-org/date-input/-/date-input-2.3.7.tgz",
+			"integrity": "sha512-TnZOjGSC/YtNm3k7uHXEOXttHqXdkE1AkUW36yIxwB9nV2jxPnWClImvc0wtZx+3tZ1XY+aWHo4ZJowJpeTbNA==",
 			"license": "MIT",
 			"dependencies": {
 				"@internationalized/date": "3.6.0",
-				"@nextui-org/form": "2.1.6",
-				"@nextui-org/react-utils": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
+				"@nextui-org/form": "2.1.7",
+				"@nextui-org/react-utils": "2.1.2",
+				"@nextui-org/shared-utils": "2.1.2",
 				"@react-aria/datepicker": "3.12.0",
 				"@react-aria/i18n": "3.12.4",
 				"@react-aria/utils": "3.26.0",
@@ -1129,21 +612,21 @@
 			}
 		},
 		"node_modules/@nextui-org/date-picker": {
-			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/@nextui-org/date-picker/-/date-picker-2.3.7.tgz",
-			"integrity": "sha512-AgUMw+pvlB6d5+LXQMZDxZhjzNFtCP/ONIZlK+kH/+X6N1JL5s7avfK0TSlFfV1x8yng6xtWBNl1vjy/ymLHpA==",
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/@nextui-org/date-picker/-/date-picker-2.3.8.tgz",
+			"integrity": "sha512-0i6Ode6rEHAVQHv3OxkB4yGnAKnS/UjJ+mKyFTLzA29LSkvmhNmquNIj9lOoenDvSvKKVB18QxuQEm1EKwgPkQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@internationalized/date": "3.6.0",
-				"@nextui-org/aria-utils": "2.2.5",
-				"@nextui-org/button": "2.2.7",
-				"@nextui-org/calendar": "2.2.7",
-				"@nextui-org/date-input": "2.3.6",
-				"@nextui-org/form": "2.1.6",
-				"@nextui-org/popover": "2.3.7",
-				"@nextui-org/react-utils": "2.1.1",
+				"@nextui-org/aria-utils": "2.2.6",
+				"@nextui-org/button": "2.2.8",
+				"@nextui-org/calendar": "2.2.8",
+				"@nextui-org/date-input": "2.3.7",
+				"@nextui-org/form": "2.1.7",
+				"@nextui-org/popover": "2.3.8",
+				"@nextui-org/react-utils": "2.1.2",
 				"@nextui-org/shared-icons": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
+				"@nextui-org/shared-utils": "2.1.2",
 				"@react-aria/datepicker": "3.12.0",
 				"@react-aria/i18n": "3.12.4",
 				"@react-aria/utils": "3.26.0",
@@ -1162,14 +645,14 @@
 			}
 		},
 		"node_modules/@nextui-org/divider": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/@nextui-org/divider/-/divider-2.2.4.tgz",
-			"integrity": "sha512-fjFeHS9x4I1TgMBKS3uuBP9XXTV+I71+Wj5jJzTf5c0bqqvTQpL3WsrfuxIT0Tfmi5gpPRafSeTBt5vOPCkdgA==",
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/@nextui-org/divider/-/divider-2.2.5.tgz",
+			"integrity": "sha512-OB8b3CU4nQ5ARIGL48izhzrAHR0mnwws+Kd5LqRCZ/1R9uRMqsq7L0gpG9FkuV2jf2FuA7xa/GLOLKbIl4CEww==",
 			"license": "MIT",
 			"dependencies": {
 				"@nextui-org/react-rsc-utils": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
-				"@nextui-org/system-rsc": "2.3.4",
+				"@nextui-org/shared-utils": "2.1.2",
+				"@nextui-org/system-rsc": "2.3.5",
 				"@react-types/shared": "3.26.0"
 			},
 			"peerDependencies": {
@@ -1188,15 +671,15 @@
 			}
 		},
 		"node_modules/@nextui-org/drawer": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/@nextui-org/drawer/-/drawer-2.2.5.tgz",
-			"integrity": "sha512-T3J1B/IX+ZPdllsNZbGoKry/jPKlniRyFGEfvY/yPpR88sEwDMMkAZVosZAx5Q+2KOiweq2jia+diGlFz+D59Q==",
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/@nextui-org/drawer/-/drawer-2.2.6.tgz",
+			"integrity": "sha512-WP0RMD/2aCr1jdpG2ygyx2fIY8TV93X5sqOnZE495iPv1ODrnj+lrj4fqewPTrouvothCmaYpY3q3q/P9vA4eg==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/framer-utils": "2.1.4",
-				"@nextui-org/modal": "2.2.5",
-				"@nextui-org/react-utils": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1"
+				"@nextui-org/framer-utils": "2.1.5",
+				"@nextui-org/modal": "2.2.6",
+				"@nextui-org/react-utils": "2.1.2",
+				"@nextui-org/shared-utils": "2.1.2"
 			},
 			"peerDependencies": {
 				"@nextui-org/system": ">=2.4.0",
@@ -1206,16 +689,16 @@
 			}
 		},
 		"node_modules/@nextui-org/dropdown": {
-			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/@nextui-org/dropdown/-/dropdown-2.3.7.tgz",
-			"integrity": "sha512-7AWurG9ImHqpJzrhlZLtEbEdBTSze7wzaz1dXLiupdfkE8NV3KVT/2sBv+WqlddlMWxEedEiaGrZWhvODOkkdQ==",
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/@nextui-org/dropdown/-/dropdown-2.3.8.tgz",
+			"integrity": "sha512-aRvxZJhrfL0GEOZpX1uFvQVuVODLU0Lc3m3xPxqc337zLF09kXLiSao09oo5AbUoOAlfUP/d1qWH6wIOoJrvIA==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/aria-utils": "2.2.5",
-				"@nextui-org/menu": "2.2.7",
-				"@nextui-org/popover": "2.3.7",
-				"@nextui-org/react-utils": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
+				"@nextui-org/aria-utils": "2.2.6",
+				"@nextui-org/menu": "2.2.8",
+				"@nextui-org/popover": "2.3.8",
+				"@nextui-org/react-utils": "2.1.2",
+				"@nextui-org/shared-utils": "2.1.2",
 				"@react-aria/focus": "3.19.0",
 				"@react-aria/menu": "3.16.0",
 				"@react-aria/overlays": "3.24.0",
@@ -1232,15 +715,15 @@
 			}
 		},
 		"node_modules/@nextui-org/form": {
-			"version": "2.1.6",
-			"resolved": "https://registry.npmjs.org/@nextui-org/form/-/form-2.1.6.tgz",
-			"integrity": "sha512-bQ4TkmHcuAEvu2UKoRIYXwvZmjaAxhY8sFYqaX9Ma1Jis1tHeu9ScxhFXDKBN1q7RiNoRdWU6o9lBcFrvHEB6w==",
+			"version": "2.1.7",
+			"resolved": "https://registry.npmjs.org/@nextui-org/form/-/form-2.1.7.tgz",
+			"integrity": "sha512-RnvvT0O/vJTKem4d1Wl7n2d/Jk3Bs6U22ko0FBSeA+y4KeZO2W7k0ls1TcLzgv8JTN0l2ELVUIBrrgkJlrrWBQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/react-utils": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
-				"@nextui-org/system": "2.4.4",
-				"@nextui-org/theme": "2.4.3",
+				"@nextui-org/react-utils": "2.1.2",
+				"@nextui-org/shared-utils": "2.1.2",
+				"@nextui-org/system": "2.4.5",
+				"@nextui-org/theme": "2.4.4",
 				"@react-aria/utils": "3.26.0",
 				"@react-stately/form": "3.1.0",
 				"@react-types/form": "3.7.8",
@@ -1254,13 +737,13 @@
 			}
 		},
 		"node_modules/@nextui-org/framer-utils": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/@nextui-org/framer-utils/-/framer-utils-2.1.4.tgz",
-			"integrity": "sha512-NC+jq5qOeNcnogBh54WxBwILj0jBhWX0mYlEeS4DOPCOgqUgYQM3tC0vJoKihd6Hh3REEJW0vxUZdrhQUraO3g==",
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@nextui-org/framer-utils/-/framer-utils-2.1.5.tgz",
+			"integrity": "sha512-z/dM29nwngCFhNCuxtCEqMbmMXG4xtXEMZh4N8FxOBEimye+2/6DIt7v0KwCY/Tx2t2URpgjCT22I8Now/SaAA==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/shared-utils": "2.1.1",
-				"@nextui-org/system": "2.4.4",
+				"@nextui-org/shared-utils": "2.1.2",
+				"@nextui-org/system": "2.4.5",
 				"@nextui-org/use-measure": "2.1.1"
 			},
 			"peerDependencies": {
@@ -1270,13 +753,13 @@
 			}
 		},
 		"node_modules/@nextui-org/image": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/@nextui-org/image/-/image-2.2.3.tgz",
-			"integrity": "sha512-erd+c7uA4FRoOOdwS6di97VVJSBbs8mXv9cOY2kZHU830e2//TKlNaE4nC7xR9ApFEAtfXjoRzSyUCIlyXmD9Q==",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/@nextui-org/image/-/image-2.2.4.tgz",
+			"integrity": "sha512-pTno8kxFtGWgBiuW1QV3z2n+9T/uXUy0x8yPL0hXyIUkvVLINlJ1xVOnpM9XRHt/ickRdeINP7itN2updyBeVQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/react-utils": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
+				"@nextui-org/react-utils": "2.1.2",
+				"@nextui-org/shared-utils": "2.1.2",
 				"@nextui-org/use-image": "2.1.1"
 			},
 			"peerDependencies": {
@@ -1287,15 +770,15 @@
 			}
 		},
 		"node_modules/@nextui-org/input": {
-			"version": "2.4.6",
-			"resolved": "https://registry.npmjs.org/@nextui-org/input/-/input-2.4.6.tgz",
-			"integrity": "sha512-HuDwTarQ6N13CrXNkX/CmvxhdojjI+K5REaB7q9wkkOIs955+0zmdhuZkkt5vfQCmnDes7pY+73vt47NLA8Tqg==",
+			"version": "2.4.7",
+			"resolved": "https://registry.npmjs.org/@nextui-org/input/-/input-2.4.7.tgz",
+			"integrity": "sha512-c5ECj9XQnfwk1ctmIGIWY/JPYbIYMPLzLSL1zohF5aqln8Af/MgERk5/T2VQISQssc0JMJv/Q7dd/MgVnv3phw==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/form": "2.1.6",
-				"@nextui-org/react-utils": "2.1.1",
+				"@nextui-org/form": "2.1.7",
+				"@nextui-org/react-utils": "2.1.2",
 				"@nextui-org/shared-icons": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
+				"@nextui-org/shared-utils": "2.1.2",
 				"@nextui-org/use-safe-layout-effect": "2.1.1",
 				"@react-aria/focus": "3.19.0",
 				"@react-aria/interactions": "3.22.5",
@@ -1314,14 +797,14 @@
 			}
 		},
 		"node_modules/@nextui-org/input-otp": {
-			"version": "2.1.6",
-			"resolved": "https://registry.npmjs.org/@nextui-org/input-otp/-/input-otp-2.1.6.tgz",
-			"integrity": "sha512-I1f3qJy63N1s+RfyACGs5OYbMvb8glsBaarJ6qrMxjY1k54AIRf0gFGHvR6uDKIDZhUBzGDXo7KvXxJbvkdnHg==",
+			"version": "2.1.7",
+			"resolved": "https://registry.npmjs.org/@nextui-org/input-otp/-/input-otp-2.1.7.tgz",
+			"integrity": "sha512-JQ4Scnll9NkPEORH1S+JypB/5YGFElESjHyClF6l4Uw6joUZrXihK+4Wqcb2Xec+hi1cRW6X86eItbPTNM+9Kg==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/form": "2.1.6",
-				"@nextui-org/react-utils": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
+				"@nextui-org/form": "2.1.7",
+				"@nextui-org/react-utils": "2.1.2",
+				"@nextui-org/shared-utils": "2.1.2",
 				"@react-aria/focus": "3.19.0",
 				"@react-aria/form": "3.0.11",
 				"@react-aria/utils": "3.26.0",
@@ -1338,14 +821,14 @@
 			}
 		},
 		"node_modules/@nextui-org/kbd": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/@nextui-org/kbd/-/kbd-2.2.4.tgz",
-			"integrity": "sha512-hggGQPTiQ2EwU67kdz/dVW6DS4KcMRgbm0ak+3qfHePfvteCHtuCPyI6CgOhymGpQuVoDTYLzKUBXuu5ow65Og==",
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/@nextui-org/kbd/-/kbd-2.2.5.tgz",
+			"integrity": "sha512-52n6XjLWnsxkQiwbQG04jEYu2xK07FEpIRycWxA0cWSFWOAiyYxaa1xYeb5va8tG8M0UCEwlvrPyxK+Wh5GmMQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/react-utils": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
-				"@nextui-org/system-rsc": "2.3.4",
+				"@nextui-org/react-utils": "2.1.2",
+				"@nextui-org/shared-utils": "2.1.2",
+				"@nextui-org/system-rsc": "2.3.5",
 				"@react-aria/utils": "3.26.0"
 			},
 			"peerDependencies": {
@@ -1355,15 +838,15 @@
 			}
 		},
 		"node_modules/@nextui-org/link": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/@nextui-org/link/-/link-2.2.5.tgz",
-			"integrity": "sha512-ZYDr9lZEmcXLP+fWgiYJi0sabkfCGCWWMdLUiC7fDWyXxLRmCD0AyA0UGP6FMfPAFI96YvUDQEs8HrbNGVXLIQ==",
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/@nextui-org/link/-/link-2.2.6.tgz",
+			"integrity": "sha512-A3+aHbuipch7Xf470qxCIbMXMW6oGX8QoT9Le2CS7YWjpNZOsGzQPQvC3Diom05vujgdlw5egses6rZak10kuQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/react-utils": "2.1.1",
+				"@nextui-org/react-utils": "2.1.2",
 				"@nextui-org/shared-icons": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
-				"@nextui-org/use-aria-link": "2.2.3",
+				"@nextui-org/shared-utils": "2.1.2",
+				"@nextui-org/use-aria-link": "2.2.4",
 				"@react-aria/focus": "3.19.0",
 				"@react-aria/link": "3.7.7",
 				"@react-aria/utils": "3.26.0",
@@ -1377,15 +860,15 @@
 			}
 		},
 		"node_modules/@nextui-org/listbox": {
-			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/@nextui-org/listbox/-/listbox-2.3.7.tgz",
-			"integrity": "sha512-U6YDqGGeuRwQg73Im0iJ6s/Ry+phOq+OXWE3PHxqNMaL6UyoEIWyitsf8Va1/VeCjAL2Ad5sdMo29jh+lZh8fA==",
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/@nextui-org/listbox/-/listbox-2.3.8.tgz",
+			"integrity": "sha512-M2j3f2zVoKlIvIv6ZMUq2BfB9WI0fxQoRV7vGSIYTDUlNMPwxmeD0xWmmtlJB5nxtmMR7G5NlzJRSTHXhFaUMA==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/aria-utils": "2.2.5",
-				"@nextui-org/divider": "2.2.4",
-				"@nextui-org/react-utils": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
+				"@nextui-org/aria-utils": "2.2.6",
+				"@nextui-org/divider": "2.2.5",
+				"@nextui-org/react-utils": "2.1.2",
+				"@nextui-org/shared-utils": "2.1.2",
 				"@nextui-org/use-is-mobile": "2.2.2",
 				"@react-aria/focus": "3.19.0",
 				"@react-aria/interactions": "3.22.5",
@@ -1404,15 +887,15 @@
 			}
 		},
 		"node_modules/@nextui-org/menu": {
-			"version": "2.2.7",
-			"resolved": "https://registry.npmjs.org/@nextui-org/menu/-/menu-2.2.7.tgz",
-			"integrity": "sha512-VWj11/Deti07eVH6YM2d+PdAONbrP5CtawCHCo13xDy6szvcSdFxNzLtcZzCpPVQ2BN35RM5Fon/VSXr1LGVgw==",
+			"version": "2.2.8",
+			"resolved": "https://registry.npmjs.org/@nextui-org/menu/-/menu-2.2.8.tgz",
+			"integrity": "sha512-JGyrAc9FEsd2rNlDwnckBkSdXe2V7cJN2Y62RRaQeJFMOZsw8tnmW9SLaL4ZB+LTmiGLORsU+b0frizu960HnA==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/aria-utils": "2.2.5",
-				"@nextui-org/divider": "2.2.4",
-				"@nextui-org/react-utils": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
+				"@nextui-org/aria-utils": "2.2.6",
+				"@nextui-org/divider": "2.2.5",
+				"@nextui-org/react-utils": "2.1.2",
+				"@nextui-org/shared-utils": "2.1.2",
 				"@nextui-org/use-is-mobile": "2.2.2",
 				"@react-aria/focus": "3.19.0",
 				"@react-aria/interactions": "3.22.5",
@@ -1431,17 +914,17 @@
 			}
 		},
 		"node_modules/@nextui-org/modal": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/@nextui-org/modal/-/modal-2.2.5.tgz",
-			"integrity": "sha512-Zp4YqLPBYyiIGcCofVQCZ7kqFXk/k+vAFZ/eulbK0lGpxCQeCZDgdXW+a4jsjVz4MXBMrZoPU90plKpr4BeVxA==",
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/@nextui-org/modal/-/modal-2.2.6.tgz",
+			"integrity": "sha512-K3jql20SKq/sJWGsjlHq92/55tGo55Ko4PT92SRvqC0vySYe9ZX1KSVpOR3/k4cQRkd+3hdbGjZBs3bVcDpB6g==",
 			"license": "MIT",
 			"dependencies": {
 				"@nextui-org/dom-animation": "2.1.1",
-				"@nextui-org/framer-utils": "2.1.4",
-				"@nextui-org/react-utils": "2.1.1",
+				"@nextui-org/framer-utils": "2.1.5",
+				"@nextui-org/react-utils": "2.1.2",
 				"@nextui-org/shared-icons": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
-				"@nextui-org/use-aria-button": "2.2.3",
+				"@nextui-org/shared-utils": "2.1.2",
+				"@nextui-org/use-aria-button": "2.2.4",
 				"@nextui-org/use-aria-modal-overlay": "2.2.3",
 				"@nextui-org/use-disclosure": "2.2.2",
 				"@nextui-org/use-draggable": "2.1.2",
@@ -1462,15 +945,15 @@
 			}
 		},
 		"node_modules/@nextui-org/navbar": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/@nextui-org/navbar/-/navbar-2.2.5.tgz",
-			"integrity": "sha512-nyFoq3i/Ru8nHKWxJLuQb2/N4wLuv9wa5C/4Hio99mMaSTlhN+dxa+vtlJBwlyxPr6/eTR1fBkgbi/ZZ1VBdkA==",
+			"version": "2.2.7",
+			"resolved": "https://registry.npmjs.org/@nextui-org/navbar/-/navbar-2.2.7.tgz",
+			"integrity": "sha512-K9puXcNDywCxYe3Ji88Ple2Oh+8RdYn4cZzBwo6oDpIsMOYva9rNURyasNa2WKrlCfdvaAKIFSuJQp4Ed64KOg==",
 			"license": "MIT",
 			"dependencies": {
 				"@nextui-org/dom-animation": "2.1.1",
-				"@nextui-org/framer-utils": "2.1.4",
-				"@nextui-org/react-utils": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
+				"@nextui-org/framer-utils": "2.1.5",
+				"@nextui-org/react-utils": "2.1.2",
+				"@nextui-org/shared-utils": "2.1.2",
 				"@nextui-org/use-scroll-position": "2.1.1",
 				"@react-aria/button": "3.11.0",
 				"@react-aria/focus": "3.19.0",
@@ -1489,16 +972,16 @@
 			}
 		},
 		"node_modules/@nextui-org/pagination": {
-			"version": "2.2.6",
-			"resolved": "https://registry.npmjs.org/@nextui-org/pagination/-/pagination-2.2.6.tgz",
-			"integrity": "sha512-JD467tBam5EQse34Q/bm8sf4LSFze4atZkCGZNZZP6rAcoNMpxXOJxVoo5DWflqYeaukInYYueyOarxnXn54HA==",
+			"version": "2.2.7",
+			"resolved": "https://registry.npmjs.org/@nextui-org/pagination/-/pagination-2.2.7.tgz",
+			"integrity": "sha512-MpKkoC+HPs3kTS8JgCyP6ZpBFtlCmn9YpI11OOhYM9faQbmv8k0D+f11CCm+GRO+yEE08MCpcZHqY3OLdASW9Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/react-utils": "2.1.1",
+				"@nextui-org/react-utils": "2.1.2",
 				"@nextui-org/shared-icons": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
+				"@nextui-org/shared-utils": "2.1.2",
 				"@nextui-org/use-intersection-observer": "2.2.2",
-				"@nextui-org/use-pagination": "2.2.2",
+				"@nextui-org/use-pagination": "2.2.3",
 				"@react-aria/focus": "3.19.0",
 				"@react-aria/i18n": "3.12.4",
 				"@react-aria/interactions": "3.22.5",
@@ -1513,18 +996,18 @@
 			}
 		},
 		"node_modules/@nextui-org/popover": {
-			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/@nextui-org/popover/-/popover-2.3.7.tgz",
-			"integrity": "sha512-mntRQXrQt/fnNU5V8aQ/awnWEwTWfZCmPIOSYQWa8+r+5puZlICSR8m8N72jLr/6VBd7wX0Scv6XjGvrehheiQ==",
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/@nextui-org/popover/-/popover-2.3.8.tgz",
+			"integrity": "sha512-hRUSD7NVlkRQjfShe6glnQAsNI9nOugLKqSzUoDt275P4fDHutEedRZUCasjOeMO+xhehIX8cyZ2mGyZAan5zQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/aria-utils": "2.2.5",
-				"@nextui-org/button": "2.2.7",
+				"@nextui-org/aria-utils": "2.2.6",
+				"@nextui-org/button": "2.2.8",
 				"@nextui-org/dom-animation": "2.1.1",
-				"@nextui-org/framer-utils": "2.1.4",
-				"@nextui-org/react-utils": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
-				"@nextui-org/use-aria-button": "2.2.3",
+				"@nextui-org/framer-utils": "2.1.5",
+				"@nextui-org/react-utils": "2.1.2",
+				"@nextui-org/shared-utils": "2.1.2",
+				"@nextui-org/use-aria-button": "2.2.4",
 				"@nextui-org/use-safe-layout-effect": "2.1.1",
 				"@react-aria/dialog": "3.5.20",
 				"@react-aria/focus": "3.19.0",
@@ -1544,13 +1027,13 @@
 			}
 		},
 		"node_modules/@nextui-org/progress": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/@nextui-org/progress/-/progress-2.2.4.tgz",
-			"integrity": "sha512-2XwzIEwUvgVLvGHq2Neo3UFyzSm/FKFj55LUGCWFQ+SiZ1JRnMZDXUOCnIzZwhDmnfCL1TOp2a0EHj05ewxwsw==",
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/@nextui-org/progress/-/progress-2.2.5.tgz",
+			"integrity": "sha512-+d317vZhBLc/1PHE2PseIlIX+N5sEO4x1dZvzISvkFQPE1igSeZ8NpbkZWZagxakqp23JoQ6HDWp/Sk7Uwr8tg==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/react-utils": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
+				"@nextui-org/react-utils": "2.1.2",
+				"@nextui-org/shared-utils": "2.1.2",
 				"@nextui-org/use-is-mounted": "2.1.1",
 				"@react-aria/i18n": "3.12.4",
 				"@react-aria/progress": "3.4.18",
@@ -1565,14 +1048,14 @@
 			}
 		},
 		"node_modules/@nextui-org/radio": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/@nextui-org/radio/-/radio-2.3.6.tgz",
-			"integrity": "sha512-zBr1LESZu8VrZZ1xj8tMdRd7HTXFfDPYeyqcxaNpqOI/ZZNHLpvoSxta9aKxDf3TbLFCt5WQz70S25DCGsljUQ==",
+			"version": "2.3.7",
+			"resolved": "https://registry.npmjs.org/@nextui-org/radio/-/radio-2.3.7.tgz",
+			"integrity": "sha512-uzPiNlkESccp18+mUnjFbi1OwzYTKMSJ8teoNWGIMQL/Q2dXhxMikL9jlTHOP25ygOPN+lxXa/nX8JiLC6G5zQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/form": "2.1.6",
-				"@nextui-org/react-utils": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
+				"@nextui-org/form": "2.1.7",
+				"@nextui-org/react-utils": "2.1.2",
+				"@nextui-org/shared-utils": "2.1.2",
 				"@react-aria/focus": "3.19.0",
 				"@react-aria/interactions": "3.22.5",
 				"@react-aria/radio": "3.10.10",
@@ -1584,64 +1067,64 @@
 			},
 			"peerDependencies": {
 				"@nextui-org/system": ">=2.4.0",
-				"@nextui-org/theme": ">=2.4.0",
+				"@nextui-org/theme": ">=2.4.3",
 				"react": ">=18 || >=19.0.0-rc.0",
 				"react-dom": ">=18 || >=19.0.0-rc.0"
 			}
 		},
 		"node_modules/@nextui-org/react": {
-			"version": "2.6.8",
-			"resolved": "https://registry.npmjs.org/@nextui-org/react/-/react-2.6.8.tgz",
-			"integrity": "sha512-w6skiTItbrzjvHl+v4bHCYNkPjPpFz0UPM/s4vZZmaky6sxihguq+mdCcSe/qkXdhmSn7b+aY9E0ygQaMvibvw==",
+			"version": "2.6.10",
+			"resolved": "https://registry.npmjs.org/@nextui-org/react/-/react-2.6.10.tgz",
+			"integrity": "sha512-50tWuyBfObL1HSUW9k9dKffoU83U/tPJR9hJBYdv2fCAzDz4cAw6Hp3ZHHDKOphTIIY+jVMIKkja2PrgLEdkrg==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/accordion": "2.2.5",
-				"@nextui-org/alert": "2.2.7",
-				"@nextui-org/autocomplete": "2.3.7",
-				"@nextui-org/avatar": "2.2.4",
-				"@nextui-org/badge": "2.2.3",
-				"@nextui-org/breadcrumbs": "2.2.4",
-				"@nextui-org/button": "2.2.7",
-				"@nextui-org/calendar": "2.2.7",
-				"@nextui-org/card": "2.2.7",
-				"@nextui-org/checkbox": "2.3.6",
-				"@nextui-org/chip": "2.2.4",
-				"@nextui-org/code": "2.2.4",
-				"@nextui-org/date-input": "2.3.6",
-				"@nextui-org/date-picker": "2.3.7",
-				"@nextui-org/divider": "2.2.4",
-				"@nextui-org/drawer": "2.2.5",
-				"@nextui-org/dropdown": "2.3.7",
-				"@nextui-org/form": "2.1.6",
-				"@nextui-org/framer-utils": "2.1.4",
-				"@nextui-org/image": "2.2.3",
-				"@nextui-org/input": "2.4.6",
-				"@nextui-org/input-otp": "2.1.6",
-				"@nextui-org/kbd": "2.2.4",
-				"@nextui-org/link": "2.2.5",
-				"@nextui-org/listbox": "2.3.7",
-				"@nextui-org/menu": "2.2.7",
-				"@nextui-org/modal": "2.2.5",
-				"@nextui-org/navbar": "2.2.5",
-				"@nextui-org/pagination": "2.2.6",
-				"@nextui-org/popover": "2.3.7",
-				"@nextui-org/progress": "2.2.4",
-				"@nextui-org/radio": "2.3.6",
-				"@nextui-org/ripple": "2.2.5",
-				"@nextui-org/scroll-shadow": "2.3.3",
-				"@nextui-org/select": "2.4.7",
-				"@nextui-org/skeleton": "2.2.3",
-				"@nextui-org/slider": "2.4.5",
-				"@nextui-org/snippet": "2.2.8",
-				"@nextui-org/spacer": "2.2.4",
-				"@nextui-org/spinner": "2.2.4",
-				"@nextui-org/switch": "2.2.6",
-				"@nextui-org/system": "2.4.4",
-				"@nextui-org/table": "2.2.6",
-				"@nextui-org/tabs": "2.2.5",
-				"@nextui-org/theme": "2.4.3",
-				"@nextui-org/tooltip": "2.2.5",
-				"@nextui-org/user": "2.2.4",
+				"@nextui-org/accordion": "2.2.6",
+				"@nextui-org/alert": "2.2.8",
+				"@nextui-org/autocomplete": "2.3.8",
+				"@nextui-org/avatar": "2.2.5",
+				"@nextui-org/badge": "2.2.4",
+				"@nextui-org/breadcrumbs": "2.2.5",
+				"@nextui-org/button": "2.2.8",
+				"@nextui-org/calendar": "2.2.8",
+				"@nextui-org/card": "2.2.8",
+				"@nextui-org/checkbox": "2.3.7",
+				"@nextui-org/chip": "2.2.5",
+				"@nextui-org/code": "2.2.5",
+				"@nextui-org/date-input": "2.3.7",
+				"@nextui-org/date-picker": "2.3.8",
+				"@nextui-org/divider": "2.2.5",
+				"@nextui-org/drawer": "2.2.6",
+				"@nextui-org/dropdown": "2.3.8",
+				"@nextui-org/form": "2.1.7",
+				"@nextui-org/framer-utils": "2.1.5",
+				"@nextui-org/image": "2.2.4",
+				"@nextui-org/input": "2.4.7",
+				"@nextui-org/input-otp": "2.1.7",
+				"@nextui-org/kbd": "2.2.5",
+				"@nextui-org/link": "2.2.6",
+				"@nextui-org/listbox": "2.3.8",
+				"@nextui-org/menu": "2.2.8",
+				"@nextui-org/modal": "2.2.6",
+				"@nextui-org/navbar": "2.2.7",
+				"@nextui-org/pagination": "2.2.7",
+				"@nextui-org/popover": "2.3.8",
+				"@nextui-org/progress": "2.2.5",
+				"@nextui-org/radio": "2.3.7",
+				"@nextui-org/ripple": "2.2.6",
+				"@nextui-org/scroll-shadow": "2.3.4",
+				"@nextui-org/select": "2.4.8",
+				"@nextui-org/skeleton": "2.2.4",
+				"@nextui-org/slider": "2.4.6",
+				"@nextui-org/snippet": "2.2.9",
+				"@nextui-org/spacer": "2.2.5",
+				"@nextui-org/spinner": "2.2.5",
+				"@nextui-org/switch": "2.2.7",
+				"@nextui-org/system": "2.4.5",
+				"@nextui-org/table": "2.2.7",
+				"@nextui-org/tabs": "2.2.6",
+				"@nextui-org/theme": "2.4.4",
+				"@nextui-org/tooltip": "2.2.6",
+				"@nextui-org/user": "2.2.5",
 				"@react-aria/visually-hidden": "3.8.18"
 			},
 			"peerDependencies": {
@@ -1660,27 +1143,27 @@
 			}
 		},
 		"node_modules/@nextui-org/react-utils": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@nextui-org/react-utils/-/react-utils-2.1.1.tgz",
-			"integrity": "sha512-cN3Z0b2bV6Nf0CYD4imsGdXbHMQqad8KivltpBv1ItbI1/FSTAv9AHTKSzDE15hd/UwOGYt3Qm7I6tWzqov55w==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@nextui-org/react-utils/-/react-utils-2.1.2.tgz",
+			"integrity": "sha512-P8toqKuksl5UgDADRxZ7lNnlcw9rynsfKPzfxi4eEKWFBPHPPFy3Nesh8tx2SJQaOxCsc+3VXB+A9la6ZHYRiA==",
 			"license": "MIT",
 			"dependencies": {
 				"@nextui-org/react-rsc-utils": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1"
+				"@nextui-org/shared-utils": "2.1.2"
 			},
 			"peerDependencies": {
 				"react": ">=18 || >=19.0.0-rc.0"
 			}
 		},
 		"node_modules/@nextui-org/ripple": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/@nextui-org/ripple/-/ripple-2.2.5.tgz",
-			"integrity": "sha512-GNYcRbVrUtdkbHKyFGRb0W8dyudH6hYY6YxYtlE5I82YwN1FovLvTRajDBbd3Bh2qNIcyUoFlmbt4h/6mM8uOQ==",
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/@nextui-org/ripple/-/ripple-2.2.6.tgz",
+			"integrity": "sha512-8bdE+nPZdT/U8H0fRaZBOAB3npfKGnv1KO2JWL2jSnN7wkO4kXZwcHqZT3aRFxqWvdsPXj8IajMpnMoM7LNYkA==",
 			"license": "MIT",
 			"dependencies": {
 				"@nextui-org/dom-animation": "2.1.1",
-				"@nextui-org/react-utils": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1"
+				"@nextui-org/react-utils": "2.1.2",
+				"@nextui-org/shared-utils": "2.1.2"
 			},
 			"peerDependencies": {
 				"@nextui-org/system": ">=2.4.0",
@@ -1691,14 +1174,14 @@
 			}
 		},
 		"node_modules/@nextui-org/scroll-shadow": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/@nextui-org/scroll-shadow/-/scroll-shadow-2.3.3.tgz",
-			"integrity": "sha512-sI68rEt/CLEVhM+TPdk1QM7h9j4bK6oWaY4xYKCOC4UtMTUMaCdWt5kqHKwX+xr4iQTPBjMCGTduGSoG9RvBgQ==",
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/@nextui-org/scroll-shadow/-/scroll-shadow-2.3.4.tgz",
+			"integrity": "sha512-/21shF/RIXOcdQp5CKy/UHZJse03O7L31ZJV1wAh8TJZOFof2oRpYIl2AibDxUnP2UR9fpjqq0b6F6e6d1Kq5Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/react-utils": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
-				"@nextui-org/use-data-scroll-overflow": "2.2.1"
+				"@nextui-org/react-utils": "2.1.2",
+				"@nextui-org/shared-utils": "2.1.2",
+				"@nextui-org/use-data-scroll-overflow": "2.2.2"
 			},
 			"peerDependencies": {
 				"@nextui-org/system": ">=2.4.0",
@@ -1708,22 +1191,22 @@
 			}
 		},
 		"node_modules/@nextui-org/select": {
-			"version": "2.4.7",
-			"resolved": "https://registry.npmjs.org/@nextui-org/select/-/select-2.4.7.tgz",
-			"integrity": "sha512-MpplLt7kWVownuvX9wQMruy9wL3Rt2GcVUteRd6wriNwj/pP3wY7OnXOgih1aNWtbVM2+PpCpgummgau2AdaAg==",
+			"version": "2.4.8",
+			"resolved": "https://registry.npmjs.org/@nextui-org/select/-/select-2.4.8.tgz",
+			"integrity": "sha512-ZX6zrMXAgOFUno1aReEvNSeUyaGkETbinzKObU0IP4/aj3I/9FjzNhj42rZrudGi356slAFRTQiYuG6O8I4wcA==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/aria-utils": "2.2.5",
-				"@nextui-org/form": "2.1.6",
-				"@nextui-org/listbox": "2.3.7",
-				"@nextui-org/popover": "2.3.7",
-				"@nextui-org/react-utils": "2.1.1",
-				"@nextui-org/scroll-shadow": "2.3.3",
+				"@nextui-org/aria-utils": "2.2.6",
+				"@nextui-org/form": "2.1.7",
+				"@nextui-org/listbox": "2.3.8",
+				"@nextui-org/popover": "2.3.8",
+				"@nextui-org/react-utils": "2.1.2",
+				"@nextui-org/scroll-shadow": "2.3.4",
 				"@nextui-org/shared-icons": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
-				"@nextui-org/spinner": "2.2.4",
-				"@nextui-org/use-aria-button": "2.2.3",
-				"@nextui-org/use-aria-multiselect": "2.4.2",
+				"@nextui-org/shared-utils": "2.1.2",
+				"@nextui-org/spinner": "2.2.5",
+				"@nextui-org/use-aria-button": "2.2.4",
+				"@nextui-org/use-aria-multiselect": "2.4.3",
 				"@nextui-org/use-safe-layout-effect": "2.1.1",
 				"@react-aria/focus": "3.19.0",
 				"@react-aria/form": "3.0.11",
@@ -1751,19 +1234,19 @@
 			}
 		},
 		"node_modules/@nextui-org/shared-utils": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@nextui-org/shared-utils/-/shared-utils-2.1.1.tgz",
-			"integrity": "sha512-qE8gZO63GqUX1ljOi/4PlwGzE84dhUS3zFIq+10/N6ePAaNjM4DwtL4ocucG3abCz4iRUueYKLIxTO2+eYyAfw==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@nextui-org/shared-utils/-/shared-utils-2.1.2.tgz",
+			"integrity": "sha512-5n0D+AGB4P9lMD1TxwtdRSuSY0cWgyXKO9mMU11Xl3zoHNiAz/SbCSTc4VBJdQJ7Y3qgNXvZICzf08+bnjjqqA==",
 			"license": "MIT"
 		},
 		"node_modules/@nextui-org/skeleton": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/@nextui-org/skeleton/-/skeleton-2.2.3.tgz",
-			"integrity": "sha512-G12blc41mCZBjOObteyqhQr4MZhEKgZGhJMVYVXr5yw+HiS9jY1LJIBPLOxs8PFo2GcYj9JVQN6rru8W9Eqxmg==",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/@nextui-org/skeleton/-/skeleton-2.2.4.tgz",
+			"integrity": "sha512-LMQI5pcYbgsJcObU9KcODvs63iswZQKuuYtDH05y4SQvDerxkjxJYj72/ld1pkwOcM8/9Tc2ya/xlk90yjlg5g==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/react-utils": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1"
+				"@nextui-org/react-utils": "2.1.2",
+				"@nextui-org/shared-utils": "2.1.2"
 			},
 			"peerDependencies": {
 				"@nextui-org/system": ">=2.4.0",
@@ -1773,14 +1256,14 @@
 			}
 		},
 		"node_modules/@nextui-org/slider": {
-			"version": "2.4.5",
-			"resolved": "https://registry.npmjs.org/@nextui-org/slider/-/slider-2.4.5.tgz",
-			"integrity": "sha512-vQXcV+Zri5+5Yfug89ffcY33XgzEP91ObsLy2r9we0H784SwQYgjk41OzAPs7gkFAnWGP1TW22jALJh3S82+YA==",
+			"version": "2.4.6",
+			"resolved": "https://registry.npmjs.org/@nextui-org/slider/-/slider-2.4.6.tgz",
+			"integrity": "sha512-BOJQcjGYr0uX/5opQauamYp26D8erMEUNqj07IxwWDIo+qnTCrUg762rAIlj3W4u3pBJJ2FkZUWbsEYDnnbi7g==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/react-utils": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
-				"@nextui-org/tooltip": "2.2.5",
+				"@nextui-org/react-utils": "2.1.2",
+				"@nextui-org/shared-utils": "2.1.2",
+				"@nextui-org/tooltip": "2.2.6",
 				"@react-aria/focus": "3.19.0",
 				"@react-aria/i18n": "3.12.4",
 				"@react-aria/interactions": "3.22.5",
@@ -1797,16 +1280,16 @@
 			}
 		},
 		"node_modules/@nextui-org/snippet": {
-			"version": "2.2.8",
-			"resolved": "https://registry.npmjs.org/@nextui-org/snippet/-/snippet-2.2.8.tgz",
-			"integrity": "sha512-zawFPrTAPi2HHxn+k9OLRvE3JoRa0YzdtIdcplAujv4T5g4zz4H+cfOKJKA6c6sCmhYHM5yBBv6q8EubmuzgTA==",
+			"version": "2.2.9",
+			"resolved": "https://registry.npmjs.org/@nextui-org/snippet/-/snippet-2.2.9.tgz",
+			"integrity": "sha512-Sc3CdW4/UCL4hhwKP0k1ffLYLo6JlI9XbB3exS77j1lS6ox/FRc+d7YylMrrNuAb/L4bIjR/TUoNiu+Rkc6u0Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/button": "2.2.7",
-				"@nextui-org/react-utils": "2.1.1",
+				"@nextui-org/button": "2.2.8",
+				"@nextui-org/react-utils": "2.1.2",
 				"@nextui-org/shared-icons": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
-				"@nextui-org/tooltip": "2.2.5",
+				"@nextui-org/shared-utils": "2.1.2",
+				"@nextui-org/tooltip": "2.2.6",
 				"@nextui-org/use-clipboard": "2.1.1",
 				"@react-aria/focus": "3.19.0",
 				"@react-aria/utils": "3.26.0"
@@ -1820,14 +1303,14 @@
 			}
 		},
 		"node_modules/@nextui-org/spacer": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/@nextui-org/spacer/-/spacer-2.2.4.tgz",
-			"integrity": "sha512-RMkC2O3I+W6qwsax5Dge8CzF2tJIDxOiC84yiQxfwRHWVe1qPXbLRu1nM5lbvjAI/4aS9NegUQ3aYnFqZwvojQ==",
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/@nextui-org/spacer/-/spacer-2.2.5.tgz",
+			"integrity": "sha512-oKh765tHx+BaD4yHewIfWGOcLWk3FsH/VBXdAsaiMyrr5MsW9LGH7e3kzBCZswBeZNN5MaDok6WZu1B0PnQIFw==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/react-utils": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
-				"@nextui-org/system-rsc": "2.3.4"
+				"@nextui-org/react-utils": "2.1.2",
+				"@nextui-org/shared-utils": "2.1.2",
+				"@nextui-org/system-rsc": "2.3.5"
 			},
 			"peerDependencies": {
 				"@nextui-org/theme": ">=2.4.0",
@@ -1836,14 +1319,14 @@
 			}
 		},
 		"node_modules/@nextui-org/spinner": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/@nextui-org/spinner/-/spinner-2.2.4.tgz",
-			"integrity": "sha512-QdCRD64+fjWmi5byO9sR3D4xbkFNh9cB01KnoR1/u7+7m/WWNFOhUkYbdkB2e53oQlNXxh0Mw02U346tC8B+5g==",
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/@nextui-org/spinner/-/spinner-2.2.5.tgz",
+			"integrity": "sha512-bU4DV1USHQUbbhzB0Qi6q27JNm1uF6r+IOs/7BfQj6sj2j124ull2BuxpyhmrAnwb2Hqj7U1goy9zMigoS37mg==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/react-utils": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
-				"@nextui-org/system-rsc": "2.3.4"
+				"@nextui-org/react-utils": "2.1.2",
+				"@nextui-org/shared-utils": "2.1.2",
+				"@nextui-org/system-rsc": "2.3.5"
 			},
 			"peerDependencies": {
 				"@nextui-org/theme": ">=2.4.0",
@@ -1852,13 +1335,13 @@
 			}
 		},
 		"node_modules/@nextui-org/switch": {
-			"version": "2.2.6",
-			"resolved": "https://registry.npmjs.org/@nextui-org/switch/-/switch-2.2.6.tgz",
-			"integrity": "sha512-YlFOvc/WnkQeldTvtTUVF7KXx8LUz6sSJJoP+xhJZtPZcfcyQlApRTvc9LpVG+eyqfLWY9ng4n85BDR2rHzoOQ==",
+			"version": "2.2.7",
+			"resolved": "https://registry.npmjs.org/@nextui-org/switch/-/switch-2.2.7.tgz",
+			"integrity": "sha512-745oSgHN4LUYFcGwN+xDSa94fBb1H+dy3RYS1sV+RzAKmHyN2OjE4x40/3W09KDQQyyA0f7y/M8gh49f4tqphw==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/react-utils": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
+				"@nextui-org/react-utils": "2.1.2",
+				"@nextui-org/shared-utils": "2.1.2",
 				"@nextui-org/use-safe-layout-effect": "2.1.1",
 				"@react-aria/focus": "3.19.0",
 				"@react-aria/interactions": "3.22.5",
@@ -1870,20 +1353,20 @@
 			},
 			"peerDependencies": {
 				"@nextui-org/system": ">=2.4.0",
-				"@nextui-org/theme": ">=2.4.0",
+				"@nextui-org/theme": ">=2.4.3",
 				"react": ">=18 || >=19.0.0-rc.0",
 				"react-dom": ">=18 || >=19.0.0-rc.0"
 			}
 		},
 		"node_modules/@nextui-org/system": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/@nextui-org/system/-/system-2.4.4.tgz",
-			"integrity": "sha512-ldlUYq7VprTEC2s3LaMxQh7S7Xeyy6DYoKkOML9XHJBgSgVXCMr5QyoxvIkO2XRl5nu6KWn2QA1vjtj2xiMjRw==",
+			"version": "2.4.5",
+			"resolved": "https://registry.npmjs.org/@nextui-org/system/-/system-2.4.5.tgz",
+			"integrity": "sha512-PNJta8tNAsWy0Sf39HCjwd73gSpZ/vhDGL9uZA+sT6kXL5ZKxCv8dLd1MNtt5Tg+v8fR4rVWHwmPuQX9rjK1MA==",
 			"license": "MIT",
 			"dependencies": {
 				"@internationalized/date": "3.6.0",
-				"@nextui-org/react-utils": "2.1.1",
-				"@nextui-org/system-rsc": "2.3.4",
+				"@nextui-org/react-utils": "2.1.2",
+				"@nextui-org/system-rsc": "2.3.5",
 				"@react-aria/i18n": "3.12.4",
 				"@react-aria/overlays": "3.24.0",
 				"@react-aria/utils": "3.26.0",
@@ -1897,9 +1380,9 @@
 			}
 		},
 		"node_modules/@nextui-org/system-rsc": {
-			"version": "2.3.4",
-			"resolved": "https://registry.npmjs.org/@nextui-org/system-rsc/-/system-rsc-2.3.4.tgz",
-			"integrity": "sha512-Y6OLFO7diYnUMe5ffDPt6sIqCaah7FOqRaJ3ZQ/We8gE8AgHnyNQxWllLtRzBqaCiIheHLo7dTMed1FFmb775A==",
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@nextui-org/system-rsc/-/system-rsc-2.3.5.tgz",
+			"integrity": "sha512-DpVLNV9LkeP1yDULFCXm2mxA9m4ygS7XYy3lwgcF9M1A8QAWB+ut+FcP+8a6va50oSHOqwvUwPDUslgXTPMBfQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@react-types/shared": "3.26.0",
@@ -1911,16 +1394,16 @@
 			}
 		},
 		"node_modules/@nextui-org/table": {
-			"version": "2.2.6",
-			"resolved": "https://registry.npmjs.org/@nextui-org/table/-/table-2.2.6.tgz",
-			"integrity": "sha512-0XZaxcsYMkIcWRbTGq9cW51pWHL6czdKUHAlj1tkRPXEcRbuUxkOWVccsz83pn2vyb56ftDA4nm1qeivcO+PkA==",
+			"version": "2.2.7",
+			"resolved": "https://registry.npmjs.org/@nextui-org/table/-/table-2.2.7.tgz",
+			"integrity": "sha512-ibVZ6OF+yd+NKPATyY16TzRJRwSa6hDr/4OUyT8w1H8dtdQ3nFd13VF+6AMpFvCmTsvB8CBwge7IqZiqqkbgzA==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/checkbox": "2.3.6",
-				"@nextui-org/react-utils": "2.1.1",
+				"@nextui-org/checkbox": "2.3.7",
+				"@nextui-org/react-utils": "2.1.2",
 				"@nextui-org/shared-icons": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
-				"@nextui-org/spacer": "2.2.4",
+				"@nextui-org/shared-utils": "2.1.2",
+				"@nextui-org/spacer": "2.2.5",
 				"@react-aria/focus": "3.19.0",
 				"@react-aria/interactions": "3.22.5",
 				"@react-aria/table": "3.16.0",
@@ -1939,15 +1422,15 @@
 			}
 		},
 		"node_modules/@nextui-org/tabs": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/@nextui-org/tabs/-/tabs-2.2.5.tgz",
-			"integrity": "sha512-lEQVO1iwnYv75+tIwwVVyUZlg2FyA9RPdXJXZWIJkCYP8xMUzPe3KFKvZkaT4UFny+typIW0pMpRrP8gJSubWg==",
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/@nextui-org/tabs/-/tabs-2.2.6.tgz",
+			"integrity": "sha512-ckommLk0fCu/BJLETXKvNHN5aqoyyujHAm1nkSH87PX247HzYd4F7VFacqwJwEHX22BlxblpKmCOkYdQqHlyuA==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/aria-utils": "2.2.5",
-				"@nextui-org/framer-utils": "2.1.4",
-				"@nextui-org/react-utils": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
+				"@nextui-org/aria-utils": "2.2.6",
+				"@nextui-org/framer-utils": "2.1.5",
+				"@nextui-org/react-utils": "2.1.2",
+				"@nextui-org/shared-utils": "2.1.2",
 				"@nextui-org/use-is-mounted": "2.1.1",
 				"@nextui-org/use-update-effect": "2.1.1",
 				"@react-aria/focus": "3.19.0",
@@ -1968,12 +1451,12 @@
 			}
 		},
 		"node_modules/@nextui-org/theme": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/@nextui-org/theme/-/theme-2.4.3.tgz",
-			"integrity": "sha512-QH9ps5NpenWU966INdGbdvZOWWUEGqxrLM2vyqkSRq+A65YON4Jhg/x1xWcSX0SJECNhoNZLh5mt6jp3jH5k8Q==",
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/@nextui-org/theme/-/theme-2.4.4.tgz",
+			"integrity": "sha512-L4MtnYa77RezHxvzQ5k5Z/+7ANg73MEFJqMMeUORUteWFv85Ugxlo/SYAL2BZIGmO5ioZt8A6NuhqT+qDDds8w==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/shared-utils": "2.1.1",
+				"@nextui-org/shared-utils": "2.1.2",
 				"clsx": "^1.2.1",
 				"color": "^4.2.3",
 				"color2k": "^2.0.2",
@@ -1987,16 +1470,16 @@
 			}
 		},
 		"node_modules/@nextui-org/tooltip": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/@nextui-org/tooltip/-/tooltip-2.2.5.tgz",
-			"integrity": "sha512-6P28S2p18uNpLHIi7trrHImtrkaxpWBimtqf3u+NZc33dYG44iBV4BfuOvp1TCFwCW+Dv5k1XLK+AMr54o1FYw==",
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/@nextui-org/tooltip/-/tooltip-2.2.6.tgz",
+			"integrity": "sha512-a8/DKDAL39nBEc/2ODP2tnGzfhmvAm0LKa0/5PxiHaY+Ym2L3+m1CVQqlT1lNVSUr8F2OohPFkF+jlP1QuntkQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/aria-utils": "2.2.5",
+				"@nextui-org/aria-utils": "2.2.6",
 				"@nextui-org/dom-animation": "2.1.1",
-				"@nextui-org/framer-utils": "2.1.4",
-				"@nextui-org/react-utils": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
+				"@nextui-org/framer-utils": "2.1.5",
+				"@nextui-org/react-utils": "2.1.2",
+				"@nextui-org/shared-utils": "2.1.2",
 				"@nextui-org/use-safe-layout-effect": "2.1.1",
 				"@react-aria/interactions": "3.22.5",
 				"@react-aria/overlays": "3.24.0",
@@ -2033,12 +1516,12 @@
 			}
 		},
 		"node_modules/@nextui-org/use-aria-button": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/@nextui-org/use-aria-button/-/use-aria-button-2.2.3.tgz",
-			"integrity": "sha512-KG5A3tgSxmwq07zYwAocnulIoyDQZ8qjmE+m0Gx0tkb438gyN4VMIv7wCWhtrmhlJCfiNLvXdxCS4MjCWv7YCQ==",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/@nextui-org/use-aria-button/-/use-aria-button-2.2.4.tgz",
+			"integrity": "sha512-Bz8l4JGzRKh6V58VX8Laq4rKZDppsnVuNCBHpMJuLo2F9ht7UKvZAEJwXcdbUZ87aui/ZC+IPYqgjvT+d8QlQg==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/shared-utils": "2.1.1",
+				"@nextui-org/shared-utils": "2.1.2",
 				"@react-aria/focus": "3.19.0",
 				"@react-aria/interactions": "3.22.5",
 				"@react-aria/utils": "3.26.0",
@@ -2050,12 +1533,12 @@
 			}
 		},
 		"node_modules/@nextui-org/use-aria-link": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/@nextui-org/use-aria-link/-/use-aria-link-2.2.3.tgz",
-			"integrity": "sha512-Qg/6t00F6aPwh8HJiwQ2BpKoaEfJ2IGPiUjOYO7m+Gc0lZ8+bYXFKb0xV+MyUQ4w7CddMvkRLQ0qF0d7VeY6sw==",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/@nextui-org/use-aria-link/-/use-aria-link-2.2.4.tgz",
+			"integrity": "sha512-e9gEtO7oQMUNTN2EAdKG4oLzndlCVghVHPoEpMxlanjvZWNlPO7/guyrN6Bpxpjz6Z80ERLK+2X8t6FCkaSb6w==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/shared-utils": "2.1.1",
+				"@nextui-org/shared-utils": "2.1.2",
 				"@react-aria/focus": "3.19.0",
 				"@react-aria/interactions": "3.22.5",
 				"@react-aria/utils": "3.26.0",
@@ -2083,9 +1566,9 @@
 			}
 		},
 		"node_modules/@nextui-org/use-aria-multiselect": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/@nextui-org/use-aria-multiselect/-/use-aria-multiselect-2.4.2.tgz",
-			"integrity": "sha512-j6xATrjpX+jRnlGKL+jbOA+RdFHEyKV/yjpKr+Y1f8NyAooqDakJuY8rw/DV2XCb7fL1DOlMva0lW5lftO0Lpw==",
+			"version": "2.4.3",
+			"resolved": "https://registry.npmjs.org/@nextui-org/use-aria-multiselect/-/use-aria-multiselect-2.4.3.tgz",
+			"integrity": "sha512-PwDA4Y5DOx0SMxc277JeZi8tMtaINTwthPhk8SaDrtOBhP+r9owS3T/W9t37xKnmrTerHwaEq4ADGQtm5/VMXQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@react-aria/i18n": "3.12.4",
@@ -2130,12 +1613,12 @@
 			}
 		},
 		"node_modules/@nextui-org/use-data-scroll-overflow": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@nextui-org/use-data-scroll-overflow/-/use-data-scroll-overflow-2.2.1.tgz",
-			"integrity": "sha512-VDXp3MgBx+D4j6TmKxnbsHrQSuqKvuMxobxBSVMHPjU2TF2ra/DD8OM//wR0z4U/u1xEQkfHEwuxvREf2xuexg==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/@nextui-org/use-data-scroll-overflow/-/use-data-scroll-overflow-2.2.2.tgz",
+			"integrity": "sha512-TFB6BuaLOsE++K1UEIPR9StkBgj9Cvvc+ccETYpmn62B7pK44DmxjkwhK0ei59wafJPIyytZ3DgdVDblfSyIXA==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/shared-utils": "2.1.1"
+				"@nextui-org/shared-utils": "2.1.2"
 			},
 			"peerDependencies": {
 				"react": ">=18 || >=19.0.0-rc.0"
@@ -2225,12 +1708,12 @@
 			}
 		},
 		"node_modules/@nextui-org/use-pagination": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/@nextui-org/use-pagination/-/use-pagination-2.2.2.tgz",
-			"integrity": "sha512-+1s5ZIuzd77rxwG4NGU3D5X5f7YVluO85QhKHIXQhSv9GmPmHM+4eeqtgs0kFoSvfaEGtEU9Eq8DBZlsXbwSvQ==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/@nextui-org/use-pagination/-/use-pagination-2.2.3.tgz",
+			"integrity": "sha512-V2WGIq4LLkTpq6EUhJg3MVvHY2ZJ63AYV9N0d52Dc3Qqok0tTRuY51dd1P+F58HyTPW84W2z4q2R8XALtzFxQw==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/shared-utils": "2.1.1",
+				"@nextui-org/shared-utils": "2.1.2",
 				"@react-aria/i18n": "3.12.4"
 			},
 			"peerDependencies": {
@@ -2265,14 +1748,14 @@
 			}
 		},
 		"node_modules/@nextui-org/user": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/@nextui-org/user/-/user-2.2.4.tgz",
-			"integrity": "sha512-dQVYSm26h9KzDqWjuKablBlDaa+IO8KKQXSvT84BFMPGBN8UY8FXZGeeopNmWHeF6hJBkK1Jn4HU+2K8GKo99Q==",
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/@nextui-org/user/-/user-2.2.5.tgz",
+			"integrity": "sha512-T9lMlFuTF+3luwgtkPPZIx0AdfyrDHu6crwN5rjpt+OTu65wF5gc7b8t8bjFzjRMNpJsiUfRxm2mTPjE9fGIAA==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextui-org/avatar": "2.2.4",
-				"@nextui-org/react-utils": "2.1.1",
-				"@nextui-org/shared-utils": "2.1.1",
+				"@nextui-org/avatar": "2.2.5",
+				"@nextui-org/react-utils": "2.1.2",
+				"@nextui-org/shared-utils": "2.1.2",
 				"@react-aria/focus": "3.19.0",
 				"@react-aria/utils": "3.26.0"
 			},
@@ -2285,8 +1768,6 @@
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
 			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.stat": "2.0.5",
@@ -2298,8 +1779,6 @@
 		},
 		"node_modules/@nodelib/fs.stat": {
 			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 8"
@@ -2307,8 +1786,6 @@
 		},
 		"node_modules/@nodelib/fs.walk": {
 			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
 			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.scandir": "2.1.5",
@@ -2320,8 +1797,6 @@
 		},
 		"node_modules/@pkgjs/parseargs": {
 			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
 			"license": "MIT",
 			"optional": true,
 			"engines": {
@@ -3608,206 +3083,8 @@
 				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
 			}
 		},
-		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.29.1.tgz",
-			"integrity": "sha512-ssKhA8RNltTZLpG6/QNkCSge+7mBQGUqJRisZ2MDQcEGaK93QESEgWK2iOpIDZ7k9zPVkG5AS3ksvD5ZWxmItw==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			]
-		},
-		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.29.1.tgz",
-			"integrity": "sha512-CaRfrV0cd+NIIcVVN/jx+hVLN+VRqnuzLRmfmlzpOzB87ajixsN/+9L5xNmkaUUvEbI5BmIKS+XTwXsHEb65Ew==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			]
-		},
-		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.29.1.tgz",
-			"integrity": "sha512-2ORr7T31Y0Mnk6qNuwtyNmy14MunTAMx06VAPI6/Ju52W10zk1i7i5U3vlDRWjhOI5quBcrvhkCHyF76bI7kEw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.29.1.tgz",
-			"integrity": "sha512-j/Ej1oanzPjmN0tirRd5K2/nncAhS9W6ICzgxV+9Y5ZsP0hiGhHJXZ2JQ53iSSjj8m6cRY6oB1GMzNn2EUt6Ng==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/@rollup/rollup-freebsd-arm64": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.29.1.tgz",
-			"integrity": "sha512-91C//G6Dm/cv724tpt7nTyP+JdN12iqeXGFM1SqnljCmi5yTXriH7B1r8AD9dAZByHpKAumqP1Qy2vVNIdLZqw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			]
-		},
-		"node_modules/@rollup/rollup-freebsd-x64": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.29.1.tgz",
-			"integrity": "sha512-hEioiEQ9Dec2nIRoeHUP6hr1PSkXzQaCUyqBDQ9I9ik4gCXQZjJMIVzoNLBRGet+hIUb3CISMh9KXuCcWVW/8w==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.29.1.tgz",
-			"integrity": "sha512-Py5vFd5HWYN9zxBv3WMrLAXY3yYJ6Q/aVERoeUFwiDGiMOWsMs7FokXihSOaT/PMWUty/Pj60XDQndK3eAfE6A==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.29.1.tgz",
-			"integrity": "sha512-RiWpGgbayf7LUcuSNIbahr0ys2YnEERD4gYdISA06wa0i8RALrnzflh9Wxii7zQJEB2/Eh74dX4y/sHKLWp5uQ==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.29.1.tgz",
-			"integrity": "sha512-Z80O+taYxTQITWMjm/YqNoe9d10OX6kDh8X5/rFCMuPqsKsSyDilvfg+vd3iXIqtfmp+cnfL1UrYirkaF8SBZA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.29.1.tgz",
-			"integrity": "sha512-fOHRtF9gahwJk3QVp01a/GqS4hBEZCV1oKglVVq13kcK3NeVlS4BwIFzOHDbmKzt3i0OuHG4zfRP0YoG5OF/rA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.29.1.tgz",
-			"integrity": "sha512-5a7q3tnlbcg0OodyxcAdrrCxFi0DgXJSoOuidFUzHZ2GixZXQs6Tc3CHmlvqKAmOs5eRde+JJxeIf9DonkmYkw==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.29.1.tgz",
-			"integrity": "sha512-9b4Mg5Yfz6mRnlSPIdROcfw1BU22FQxmfjlp/CShWwO3LilKQuMISMTtAu/bxmmrE6A902W2cZJuzx8+gJ8e9w==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.29.1.tgz",
-			"integrity": "sha512-G5pn0NChlbRM8OJWpJFMX4/i8OEU538uiSv0P6roZcbpe/WfhEO+AT8SHVKfp8qhDQzaz7Q+1/ixMy7hBRidnQ==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.29.1.tgz",
-			"integrity": "sha512-WM9lIkNdkhVwiArmLxFXpWndFGuOka4oJOZh8EP3Vb8q5lzdSCBuhjavJsw68Q9AKDGeOOIHYzYm4ZFvmWez5g==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
 			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.29.1.tgz",
-			"integrity": "sha512-87xYCwb0cPGZFoGiErT1eDcssByaLX4fc0z2nRM6eMtV9njAfEE6OW3UniAoDhX4Iq5xQVpE6qO9aJbCFumKYQ==",
 			"cpu": [
 				"x64"
 			],
@@ -3820,8 +3097,6 @@
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
 			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.29.1.tgz",
-			"integrity": "sha512-xufkSNppNOdVRCEC4WKvlR1FBDyqCSCpQeMMgv9ZyXqqtKBfkw1yfGMTUTs9Qsl6WQbJnsGboWCp7pJGkeMhKA==",
 			"cpu": [
 				"x64"
 			],
@@ -3832,52 +3107,8 @@
 				"linux"
 			]
 		},
-		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.29.1.tgz",
-			"integrity": "sha512-F2OiJ42m77lSkizZQLuC+jiZ2cgueWQL5YC9tjo3AgaEw+KJmVxHGSyQfDUoYR9cci0lAywv2Clmckzulcq6ig==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
-		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.29.1.tgz",
-			"integrity": "sha512-rYRe5S0FcjlOBZQHgbTKNrqxCBUmgDJem/VQTCcTnA2KCabYSWQDrytOzX7avb79cAAweNmMUb/Zw18RNd4mng==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
-		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.29.1.tgz",
-			"integrity": "sha512-+10CMg9vt1MoHj6x1pxyjPSMjHTIlqs8/tBztXvPAx24SKs9jwVnKqHJumlH/IzhaPUaj3T6T6wfZr8okdXaIg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
 		"node_modules/@swc/core": {
 			"version": "1.10.1",
-			"resolved": "https://registry.npmjs.org/@swc/core/-/core-1.10.1.tgz",
-			"integrity": "sha512-rQ4dS6GAdmtzKiCRt3LFVxl37FaY1cgL9kSUTnhQ2xc3fmHOd7jdJK/V4pSZMG1ruGTd0bsi34O2R0Olg9Zo/w==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
@@ -3913,95 +3144,8 @@
 				}
 			}
 		},
-		"node_modules/@swc/core-darwin-arm64": {
-			"version": "1.10.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.10.1.tgz",
-			"integrity": "sha512-NyELPp8EsVZtxH/mEqvzSyWpfPJ1lugpTQcSlMduZLj1EASLO4sC8wt8hmL1aizRlsbjCX+r0PyL+l0xQ64/6Q==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-darwin-x64": {
-			"version": "1.10.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.10.1.tgz",
-			"integrity": "sha512-L4BNt1fdQ5ZZhAk5qoDfUnXRabDOXKnXBxMDJ+PWLSxOGBbWE6aJTnu4zbGjJvtot0KM46m2LPAPY8ttknqaZA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-linux-arm-gnueabihf": {
-			"version": "1.10.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.10.1.tgz",
-			"integrity": "sha512-Y1u9OqCHgvVp2tYQAJ7hcU9qO5brDMIrA5R31rwWQIAKDkJKtv3IlTHF0hrbWk1wPR0ZdngkQSJZple7G+Grvw==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-linux-arm64-gnu": {
-			"version": "1.10.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.10.1.tgz",
-			"integrity": "sha512-tNQHO/UKdtnqjc7o04iRXng1wTUXPgVd8Y6LI4qIbHVoVPwksZydISjMcilKNLKIwOoUQAkxyJ16SlOAeADzhQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-linux-arm64-musl": {
-			"version": "1.10.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.10.1.tgz",
-			"integrity": "sha512-x0L2Pd9weQ6n8dI1z1Isq00VHFvpBClwQJvrt3NHzmR+1wCT/gcYl1tp9P5xHh3ldM8Cn4UjWCw+7PaUgg8FcQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/@swc/core-linux-x64-gnu": {
 			"version": "1.10.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.10.1.tgz",
-			"integrity": "sha512-yyYEwQcObV3AUsC79rSzN9z6kiWxKAVJ6Ntwq2N9YoZqSPYph+4/Am5fM1xEQYf/kb99csj0FgOelomJSobxQA==",
 			"cpu": [
 				"x64"
 			],
@@ -4017,8 +3161,6 @@
 		},
 		"node_modules/@swc/core-linux-x64-musl": {
 			"version": "1.10.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.10.1.tgz",
-			"integrity": "sha512-tcaS43Ydd7Fk7sW5ROpaf2Kq1zR+sI5K0RM+0qYLYYurvsJruj3GhBCaiN3gkzd8m/8wkqNqtVklWaQYSDsyqA==",
 			"cpu": [
 				"x64"
 			],
@@ -4032,68 +3174,13 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/@swc/core-win32-arm64-msvc": {
-			"version": "1.10.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.10.1.tgz",
-			"integrity": "sha512-D3Qo1voA7AkbOzQ2UGuKNHfYGKL6eejN8VWOoQYtGHHQi1p5KK/Q7V1ku55oxXBsj79Ny5FRMqiRJpVGad7bjQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-win32-ia32-msvc": {
-			"version": "1.10.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.10.1.tgz",
-			"integrity": "sha512-WalYdFoU3454Og+sDKHM1MrjvxUGwA2oralknXkXL8S0I/8RkWZOB++p3pLaGbTvOO++T+6znFbQdR8KRaa7DA==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-win32-x64-msvc": {
-			"version": "1.10.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.10.1.tgz",
-			"integrity": "sha512-JWobfQDbTnoqaIwPKQ3DVSywihVXlQMbDuwik/dDWlj33A8oEHcjPOGs4OqcA3RHv24i+lfCQpM3Mn4FAMfacA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/@swc/counter": {
 			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
-			"integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
 			"dev": true,
 			"license": "Apache-2.0"
 		},
 		"node_modules/@swc/helpers": {
 			"version": "0.5.15",
-			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-			"integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.8.0"
@@ -4101,8 +3188,6 @@
 		},
 		"node_modules/@swc/types": {
 			"version": "0.1.17",
-			"resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.17.tgz",
-			"integrity": "sha512-V5gRru+aD8YVyCOMAjMpWR1Ui577DD5KSJsHP8RAxopAH22jFz6GZd/qxqjO6MJHQhcsjvjOFXyDhyLQUnMveQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -4138,14 +3223,10 @@
 		},
 		"node_modules/@types/cookie": {
 			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
-			"integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
 			"license": "MIT"
 		},
 		"node_modules/@types/estree": {
 			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -4166,15 +3247,11 @@
 		},
 		"node_modules/@types/prop-types": {
 			"version": "15.7.14",
-			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
-			"integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/react": {
 			"version": "18.3.18",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
-			"integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4184,8 +3261,6 @@
 		},
 		"node_modules/@types/react-dom": {
 			"version": "18.3.5",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
-			"integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
@@ -4194,8 +3269,6 @@
 		},
 		"node_modules/@vitejs/plugin-react-swc": {
 			"version": "3.7.2",
-			"resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.7.2.tgz",
-			"integrity": "sha512-y0byko2b2tSVVf5Gpng1eEhX1OvPC7x8yns1Fx8jDzlJp4LS6CMkCPfLw47cjyoMrshQDoQw4qcgjsU9VvlCew==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4207,15 +3280,11 @@
 		},
 		"node_modules/@zeit/schemas": {
 			"version": "2.36.0",
-			"resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.36.0.tgz",
-			"integrity": "sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/accepts": {
 			"version": "1.3.8",
-			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-			"integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4228,8 +3297,6 @@
 		},
 		"node_modules/ajv": {
 			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4245,8 +3312,6 @@
 		},
 		"node_modules/ansi-align": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
-			"integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -4255,8 +3320,6 @@
 		},
 		"node_modules/ansi-align/node_modules/ansi-regex": {
 			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4265,15 +3328,11 @@
 		},
 		"node_modules/ansi-align/node_modules/emoji-regex": {
 			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/ansi-align/node_modules/string-width": {
 			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4287,8 +3346,6 @@
 		},
 		"node_modules/ansi-align/node_modules/strip-ansi": {
 			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4300,8 +3357,6 @@
 		},
 		"node_modules/ansi-regex": {
 			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-			"integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -4312,8 +3367,6 @@
 		},
 		"node_modules/ansi-styles": {
 			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-			"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -4324,14 +3377,10 @@
 		},
 		"node_modules/any-promise": {
 			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
 			"license": "MIT"
 		},
 		"node_modules/anymatch": {
 			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-			"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
 			"license": "ISC",
 			"dependencies": {
 				"normalize-path": "^3.0.0",
@@ -4343,8 +3392,6 @@
 		},
 		"node_modules/arch": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
-			"integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -4364,14 +3411,10 @@
 		},
 		"node_modules/arg": {
 			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-			"integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
 			"license": "MIT"
 		},
 		"node_modules/autoprefixer": {
 			"version": "10.4.20",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
-			"integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
 			"dev": true,
 			"funding": [
 				{
@@ -4408,14 +3451,10 @@
 		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"license": "MIT"
 		},
 		"node_modules/binary-extensions": {
 			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-			"integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -4426,8 +3465,6 @@
 		},
 		"node_modules/boxen": {
 			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/boxen/-/boxen-7.0.0.tgz",
-			"integrity": "sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4449,8 +3486,6 @@
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4460,8 +3495,6 @@
 		},
 		"node_modules/braces": {
 			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
 			"license": "MIT",
 			"dependencies": {
 				"fill-range": "^7.1.1"
@@ -4472,8 +3505,6 @@
 		},
 		"node_modules/browser-tabs-lock": {
 			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/browser-tabs-lock/-/browser-tabs-lock-1.3.0.tgz",
-			"integrity": "sha512-g6nHaobTiT0eMZ7jh16YpD2kcjAp+PInbiVq3M1x6KKaEIVhT4v9oURNIpZLOZ3LQbQ3XYfNhMAb/9hzNLIWrw==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"peer": true,
@@ -4483,8 +3514,6 @@
 		},
 		"node_modules/browserslist": {
 			"version": "4.24.3",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.3.tgz",
-			"integrity": "sha512-1CPmv8iobE2fyRMV97dAcMVegvvWKxmq94hkLiAkUGwKVTyDLw33K+ZxiFrREKmmps4rIw6grcCFCnTMSZ/YiA==",
 			"dev": true,
 			"funding": [
 				{
@@ -4516,8 +3545,6 @@
 		},
 		"node_modules/bytes": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-			"integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4526,8 +3553,6 @@
 		},
 		"node_modules/camelcase": {
 			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
-			"integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4539,8 +3564,6 @@
 		},
 		"node_modules/camelcase-css": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
-			"integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
@@ -4548,8 +3571,6 @@
 		},
 		"node_modules/caniuse-lite": {
 			"version": "1.0.30001690",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz",
-			"integrity": "sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==",
 			"dev": true,
 			"funding": [
 				{
@@ -4569,8 +3590,6 @@
 		},
 		"node_modules/chalk": {
 			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
-			"integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4582,8 +3601,6 @@
 		},
 		"node_modules/chalk-template": {
 			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
-			"integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4598,8 +3615,6 @@
 		},
 		"node_modules/chalk-template/node_modules/ansi-styles": {
 			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4614,8 +3629,6 @@
 		},
 		"node_modules/chalk-template/node_modules/chalk": {
 			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4631,8 +3644,6 @@
 		},
 		"node_modules/chokidar": {
 			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-			"integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
 			"license": "MIT",
 			"dependencies": {
 				"anymatch": "~3.1.2",
@@ -4655,8 +3666,6 @@
 		},
 		"node_modules/chokidar/node_modules/glob-parent": {
 			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
 			"license": "ISC",
 			"dependencies": {
 				"is-glob": "^4.0.1"
@@ -4667,8 +3676,6 @@
 		},
 		"node_modules/cli-boxes": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
-			"integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4680,8 +3687,6 @@
 		},
 		"node_modules/clipboardy": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-3.0.0.tgz",
-			"integrity": "sha512-Su+uU5sr1jkUy1sGRpLKjKrvEOVXgSgiSInwa/qeID6aJ07yh+5NWc3h2QfjHjBnfX4LhtFcuAWKUsJ3r+fjbg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4720,8 +3725,6 @@
 		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
 			"license": "MIT",
 			"dependencies": {
 				"color-name": "~1.1.4"
@@ -4732,8 +3735,6 @@
 		},
 		"node_modules/color-name": {
 			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"license": "MIT"
 		},
 		"node_modules/color-string": {
@@ -4754,8 +3755,6 @@
 		},
 		"node_modules/commander": {
 			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-			"integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
@@ -4763,8 +3762,6 @@
 		},
 		"node_modules/compressible": {
 			"version": "2.0.18",
-			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
-			"integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4776,8 +3773,6 @@
 		},
 		"node_modules/compression": {
 			"version": "1.7.4",
-			"resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
-			"integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4801,15 +3796,11 @@
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/content-disposition": {
 			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-			"integrity": "sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4818,8 +3809,6 @@
 		},
 		"node_modules/cookie": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
-			"integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -4827,8 +3816,6 @@
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.1.0",
@@ -4841,8 +3828,6 @@
 		},
 		"node_modules/cssesc": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-			"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
 			"license": "MIT",
 			"bin": {
 				"cssesc": "bin/cssesc"
@@ -4853,15 +3838,11 @@
 		},
 		"node_modules/csstype": {
 			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-			"integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/debug": {
 			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4876,8 +3857,6 @@
 		},
 		"node_modules/deep-extend": {
 			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4895,39 +3874,27 @@
 		},
 		"node_modules/didyoumean": {
 			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
-			"integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/dlv": {
 			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-			"integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
 			"license": "MIT"
 		},
 		"node_modules/eastasianwidth": {
 			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
 			"version": "1.5.75",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.75.tgz",
-			"integrity": "sha512-Lf3++DumRE/QmweGjU+ZcKqQ+3bKkU/qjaKYhIJKEOhgIO9Xs6IiAQFkfFoj+RhgDk4LUeNsLo6plExHqSyu6Q==",
 			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/emoji-regex": {
 			"version": "9.2.2",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
 			"license": "MIT"
 		},
 		"node_modules/esbuild": {
 			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.0.tgz",
-			"integrity": "sha512-FuLPevChGDshgSicjisSooU0cemp/sGXR841D5LHMB7mTVOmsEHcAxaH3irL53+8YDIeVNQEySh4DaYU/iuPqQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -4966,8 +3933,6 @@
 		},
 		"node_modules/escalade": {
 			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4976,8 +3941,6 @@
 		},
 		"node_modules/execa": {
 			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5000,15 +3963,11 @@
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/fast-glob": {
 			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-			"integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
 			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -5023,8 +3982,6 @@
 		},
 		"node_modules/fast-glob/node_modules/glob-parent": {
 			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
 			"license": "ISC",
 			"dependencies": {
 				"is-glob": "^4.0.1"
@@ -5035,8 +3992,6 @@
 		},
 		"node_modules/fastq": {
 			"version": "1.17.1",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
-			"integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
 			"license": "ISC",
 			"dependencies": {
 				"reusify": "^1.0.4"
@@ -5044,8 +3999,6 @@
 		},
 		"node_modules/fill-range": {
 			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
 			"license": "MIT",
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
@@ -5065,8 +4018,6 @@
 		},
 		"node_modules/foreground-child": {
 			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
-			"integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
 			"license": "ISC",
 			"dependencies": {
 				"cross-spawn": "^7.0.0",
@@ -5081,8 +4032,6 @@
 		},
 		"node_modules/foreground-child/node_modules/signal-exit": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
 			"license": "ISC",
 			"engines": {
 				"node": ">=14"
@@ -5093,8 +4042,6 @@
 		},
 		"node_modules/fraction.js": {
 			"version": "4.3.7",
-			"resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
-			"integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5107,8 +4054,6 @@
 		},
 		"node_modules/framer-motion": {
 			"version": "11.15.0",
-			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.15.0.tgz",
-			"integrity": "sha512-MLk8IvZntxOMg7lDBLw2qgTHHv664bYoYmnFTmE0Gm/FW67aOJk0WM3ctMcG+Xhcv+vh5uyyXwxvxhSeJzSe+w==",
 			"license": "MIT",
 			"dependencies": {
 				"motion-dom": "^11.14.3",
@@ -5132,24 +4077,8 @@
 				}
 			}
 		},
-		"node_modules/fsevents": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-			}
-		},
 		"node_modules/function-bind": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -5157,8 +4086,6 @@
 		},
 		"node_modules/get-stream": {
 			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5170,8 +4097,6 @@
 		},
 		"node_modules/glob": {
 			"version": "10.4.5",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
 			"license": "ISC",
 			"dependencies": {
 				"foreground-child": "^3.1.0",
@@ -5190,8 +4115,6 @@
 		},
 		"node_modules/glob-parent": {
 			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
 			"license": "ISC",
 			"dependencies": {
 				"is-glob": "^4.0.3"
@@ -5202,8 +4125,6 @@
 		},
 		"node_modules/glob/node_modules/brace-expansion": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"
@@ -5211,8 +4132,6 @@
 		},
 		"node_modules/glob/node_modules/minimatch": {
 			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
 			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
@@ -5226,8 +4145,6 @@
 		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5236,8 +4153,6 @@
 		},
 		"node_modules/hasown": {
 			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
 			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.2"
@@ -5248,8 +4163,6 @@
 		},
 		"node_modules/human-signals": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -5258,8 +4171,6 @@
 		},
 		"node_modules/ini": {
 			"version": "1.3.8",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -5287,8 +4198,6 @@
 		},
 		"node_modules/intl-tel-input": {
 			"version": "17.0.21",
-			"resolved": "https://registry.npmjs.org/intl-tel-input/-/intl-tel-input-17.0.21.tgz",
-			"integrity": "sha512-TfyPxLe41QZPOf6RqBxRE2dpQ0FThB/PBD/gRbxVhGW7IuYg30QD90x/vjmEo4vkZw7j8etxpVcjIZVRcG+Otw==",
 			"license": "MIT"
 		},
 		"node_modules/is-arrayish": {
@@ -5299,8 +4208,6 @@
 		},
 		"node_modules/is-binary-path": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
 			"license": "MIT",
 			"dependencies": {
 				"binary-extensions": "^2.0.0"
@@ -5311,8 +4218,6 @@
 		},
 		"node_modules/is-core-module": {
 			"version": "2.16.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-			"integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
 			"license": "MIT",
 			"dependencies": {
 				"hasown": "^2.0.2"
@@ -5326,8 +4231,6 @@
 		},
 		"node_modules/is-docker": {
 			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-			"integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -5342,8 +4245,6 @@
 		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -5351,8 +4252,6 @@
 		},
 		"node_modules/is-fullwidth-code-point": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -5360,8 +4259,6 @@
 		},
 		"node_modules/is-glob": {
 			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
 			"license": "MIT",
 			"dependencies": {
 				"is-extglob": "^2.1.1"
@@ -5372,8 +4269,6 @@
 		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
@@ -5381,8 +4276,6 @@
 		},
 		"node_modules/is-port-reachable": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/is-port-reachable/-/is-port-reachable-4.0.0.tgz",
-			"integrity": "sha512-9UoipoxYmSk6Xy7QFgRv2HDyaysmgSG75TFQs6S+3pDM7ZhKTF/bskZV+0UlABHzKjNVhPjYCLfeZUEg1wXxig==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5394,8 +4287,6 @@
 		},
 		"node_modules/is-stream": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5407,8 +4298,6 @@
 		},
 		"node_modules/is-wsl": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5420,14 +4309,10 @@
 		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"license": "ISC"
 		},
 		"node_modules/jackspeak": {
 			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"@isaacs/cliui": "^8.0.2"
@@ -5441,8 +4326,6 @@
 		},
 		"node_modules/jiti": {
 			"version": "1.21.7",
-			"resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
-			"integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
 			"license": "MIT",
 			"bin": {
 				"jiti": "bin/jiti.js"
@@ -5450,21 +4333,15 @@
 		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
 			"license": "MIT"
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/lefthook": {
 			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/lefthook/-/lefthook-1.10.0.tgz",
-			"integrity": "sha512-UumSwQpbI8z4kEj6MfrQ2aNvxAGO/kUHEH009tpEFOSqqsCmEHmzekRReOAZS17k5dit2xThnHRKvAvwbhsvFA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -5484,80 +4361,8 @@
 				"lefthook-windows-x64": "1.10.0"
 			}
 		},
-		"node_modules/lefthook-darwin-arm64": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-1.10.0.tgz",
-			"integrity": "sha512-UeVe5Jtb4uuN8elqDpw3Uf7HnZ183xrnoc9Wfqzw2Yc/qt1uHWkBQGqSlWe83HkBaMBlwuGF+V5mcycz/Dhd+w==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/lefthook-darwin-x64": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-1.10.0.tgz",
-			"integrity": "sha512-o3nbkFcwZueoYgD/fsodtLFicM5FGFgT0lx6Vph3FBbHmneLuYrfipn38Y8C4JdMJsRhkqHAt8E8VTIZ7fhlZA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/lefthook-freebsd-arm64": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-1.10.0.tgz",
-			"integrity": "sha512-bu0hg5cTCsvPEJUMvGl5QujgyloXfae9c/YkVHgLhkx5jdUR68QfGONoszEQenyWm6wQgVgUSN4MRDud9fro7w==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			]
-		},
-		"node_modules/lefthook-freebsd-x64": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-1.10.0.tgz",
-			"integrity": "sha512-vElX6xKbdKtma91rGvIrtt0TX/1hMIvh1lF2QHHKuouce3GAConget0eEBkhWIWYZg3wXU0/0lIJatZq1daC1g==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			]
-		},
-		"node_modules/lefthook-linux-arm64": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-1.10.0.tgz",
-			"integrity": "sha512-oLJFRguZTS1L8wpoawRBwawVRcHRSvq7R38qq1n83Pz/Z/2SdocsRjkARNiqSI8B0piZiX+6863H1ycvd4P3Gw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
 		"node_modules/lefthook-linux-x64": {
 			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-1.10.0.tgz",
-			"integrity": "sha512-38VUuekwlSRKeMrktmj0FsQ0Bu3Z8XKGK66gnvDR5vUGd0ftZ+SgvgB1GVWHeySDepox0Mvwz1mKIZorT62g5g==",
 			"cpu": [
 				"x64"
 			],
@@ -5566,68 +4371,10 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
-		},
-		"node_modules/lefthook-openbsd-arm64": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-1.10.0.tgz",
-			"integrity": "sha512-qFCABCaTdOpoh6kaCDuv91y9L7VuZE4V7Q91bcYtxUql/JEO0y0uCoz8fmkTfLogWWuFmp3V2ecuIIday1RBYQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			]
-		},
-		"node_modules/lefthook-openbsd-x64": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/lefthook-openbsd-x64/-/lefthook-openbsd-x64-1.10.0.tgz",
-			"integrity": "sha512-c3ObgVG64bybz6PfHNLhdwzDADKfjX+2bxMC4FVfutU8TYRrkfyeM67tzrqXOm37TwiKI+u0f4hpn26Fe1TNnQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			]
-		},
-		"node_modules/lefthook-windows-arm64": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-1.10.0.tgz",
-			"integrity": "sha512-m42wiAIQoesl7aCZsLcMQTTnGA08sIB/JjiI892CUFX/bTf2V4sH1arSgmqrA0KKl7PUW4WEDaeqLZSNAPMOGA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
-		"node_modules/lefthook-windows-x64": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-1.10.0.tgz",
-			"integrity": "sha512-PL2vmj30X8i5DEMU5Sg25U0luakP9EFyG0gpMLJ97IyJYRO7Drka0tDOwbBH7RexRY4HP4FELLhkGvwuEQAyLg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
 			]
 		},
 		"node_modules/lilconfig": {
 			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
-			"integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=14"
@@ -5638,21 +4385,15 @@
 		},
 		"node_modules/lines-and-columns": {
 			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
 			"license": "MIT"
 		},
 		"node_modules/lodash": {
 			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 			"license": "MIT",
 			"peer": true
 		},
 		"node_modules/loose-envify": {
 			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
 			"license": "MIT",
 			"dependencies": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
@@ -5663,21 +4404,15 @@
 		},
 		"node_modules/lru-cache": {
 			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
 			"license": "ISC"
 		},
 		"node_modules/merge-stream": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 8"
@@ -5685,8 +4420,6 @@
 		},
 		"node_modules/micromatch": {
 			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
 			"license": "MIT",
 			"dependencies": {
 				"braces": "^3.0.3",
@@ -5698,8 +4431,6 @@
 		},
 		"node_modules/mime-db": {
 			"version": "1.53.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.53.0.tgz",
-			"integrity": "sha512-oHlN/w+3MQ3rba9rqFr6V/ypF10LSkdwUysQL7GkXoTgIWeV+tcXGA852TBxH+gsh8UWoyhR1hKcoMJTuWflpg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5708,8 +4439,6 @@
 		},
 		"node_modules/mime-types": {
 			"version": "2.1.35",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5721,8 +4450,6 @@
 		},
 		"node_modules/mime-types/node_modules/mime-db": {
 			"version": "1.52.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5731,8 +4458,6 @@
 		},
 		"node_modules/mimic-fn": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5741,8 +4466,6 @@
 		},
 		"node_modules/minimatch": {
 			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -5754,8 +4477,6 @@
 		},
 		"node_modules/minimist": {
 			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -5764,8 +4485,6 @@
 		},
 		"node_modules/minipass": {
 			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
 			"license": "ISC",
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
@@ -5773,27 +4492,19 @@
 		},
 		"node_modules/motion-dom": {
 			"version": "11.14.3",
-			"resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.14.3.tgz",
-			"integrity": "sha512-lW+D2wBy5vxLJi6aCP0xyxTxlTfiu+b+zcpVbGVFUxotwThqhdpPRSmX8xztAgtZMPMeU0WGVn/k1w4I+TbPqA==",
 			"license": "MIT"
 		},
 		"node_modules/motion-utils": {
 			"version": "11.14.3",
-			"resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.14.3.tgz",
-			"integrity": "sha512-Xg+8xnqIJTpr0L/cidfTTBFkvRw26ZtGGuIhA94J9PQ2p4mEa06Xx7QVYZH0BP+EpMSaDlu+q0I0mmvwADPsaQ==",
 			"license": "MIT"
 		},
 		"node_modules/ms": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/mz": {
 			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-			"integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
 			"license": "MIT",
 			"dependencies": {
 				"any-promise": "^1.0.0",
@@ -5803,8 +4514,6 @@
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.8",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-			"integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
 			"funding": [
 				{
 					"type": "github",
@@ -5821,8 +4530,6 @@
 		},
 		"node_modules/negotiator": {
 			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-			"integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5831,15 +4538,11 @@
 		},
 		"node_modules/node-releases": {
 			"version": "2.0.19",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-			"integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -5847,8 +4550,6 @@
 		},
 		"node_modules/normalize-range": {
 			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-			"integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5857,8 +4558,6 @@
 		},
 		"node_modules/npm-run-path": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5870,8 +4569,6 @@
 		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -5879,8 +4576,6 @@
 		},
 		"node_modules/object-hash": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
-			"integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
@@ -5888,8 +4583,6 @@
 		},
 		"node_modules/on-headers": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-			"integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5898,8 +4591,6 @@
 		},
 		"node_modules/onetime": {
 			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5914,21 +4605,15 @@
 		},
 		"node_modules/package-json-from-dist": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
 			"license": "BlueOak-1.0.0"
 		},
 		"node_modules/path-is-inside": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==",
 			"dev": true,
 			"license": "(WTFPL OR MIT)"
 		},
 		"node_modules/path-key": {
 			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -5936,14 +4621,10 @@
 		},
 		"node_modules/path-parse": {
 			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
 			"license": "MIT"
 		},
 		"node_modules/path-scurry": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"lru-cache": "^10.2.0",
@@ -5958,21 +4639,15 @@
 		},
 		"node_modules/path-to-regexp": {
 			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
-			"integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=8.6"
@@ -5983,8 +4658,6 @@
 		},
 		"node_modules/pify": {
 			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -5992,8 +4665,6 @@
 		},
 		"node_modules/pirates": {
 			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
-			"integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
@@ -6001,8 +4672,6 @@
 		},
 		"node_modules/postcss": {
 			"version": "8.4.49",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-			"integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -6029,8 +4698,6 @@
 		},
 		"node_modules/postcss-import": {
 			"version": "15.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
-			"integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
 			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.0.0",
@@ -6046,8 +4713,6 @@
 		},
 		"node_modules/postcss-js": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
-			"integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
 			"license": "MIT",
 			"dependencies": {
 				"camelcase-css": "^2.0.1"
@@ -6065,8 +4730,6 @@
 		},
 		"node_modules/postcss-load-config": {
 			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
-			"integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -6100,8 +4763,6 @@
 		},
 		"node_modules/postcss-nested": {
 			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
-			"integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -6125,8 +4786,6 @@
 		},
 		"node_modules/postcss-selector-parser": {
 			"version": "6.1.2",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-			"integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
 			"license": "MIT",
 			"dependencies": {
 				"cssesc": "^3.0.0",
@@ -6138,14 +4797,10 @@
 		},
 		"node_modules/postcss-value-parser": {
 			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
 			"license": "MIT"
 		},
 		"node_modules/prop-types": {
 			"version": "15.8.1",
-			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
 			"license": "MIT",
 			"dependencies": {
 				"loose-envify": "^1.4.0",
@@ -6155,8 +4810,6 @@
 		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -6165,14 +4818,10 @@
 		},
 		"node_modules/qr.js": {
 			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
-			"integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ==",
 			"license": "MIT"
 		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
 			"funding": [
 				{
 					"type": "github",
@@ -6191,8 +4840,6 @@
 		},
 		"node_modules/range-parser": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-			"integrity": "sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -6201,8 +4848,6 @@
 		},
 		"node_modules/rc": {
 			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 			"dev": true,
 			"license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
 			"dependencies": {
@@ -6217,8 +4862,6 @@
 		},
 		"node_modules/react": {
 			"version": "18.3.1",
-			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
 			"license": "MIT",
 			"dependencies": {
 				"loose-envify": "^1.1.0"
@@ -6229,8 +4872,6 @@
 		},
 		"node_modules/react-dom": {
 			"version": "18.3.1",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
 			"license": "MIT",
 			"dependencies": {
 				"loose-envify": "^1.1.0",
@@ -6242,14 +4883,10 @@
 		},
 		"node_modules/react-is": {
 			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
 			"license": "MIT"
 		},
 		"node_modules/react-qr-code": {
 			"version": "2.0.15",
-			"resolved": "https://registry.npmjs.org/react-qr-code/-/react-qr-code-2.0.15.tgz",
-			"integrity": "sha512-MkZcjEXqVKqXEIMVE0mbcGgDpkfSdd8zhuzXEl9QzYeNcw8Hq2oVIzDLWuZN2PQBwM5PWjc2S31K8Q1UbcFMfw==",
 			"license": "MIT",
 			"dependencies": {
 				"prop-types": "^15.8.1",
@@ -6261,8 +4898,6 @@
 		},
 		"node_modules/react-router": {
 			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/react-router/-/react-router-7.1.0.tgz",
-			"integrity": "sha512-VcFhWqkNIcojDRYaUO8qV0Jib52s9ULpCp3nkBbmrvtoCVFRp6tmk3tJ2w9BZauVctA1YRnJlFYDn9iJRuCpGA==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/cookie": "^0.6.0",
@@ -6285,8 +4920,6 @@
 		},
 		"node_modules/react-router-dom": {
 			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.1.0.tgz",
-			"integrity": "sha512-F4/nYBC9e4s0/ZjxM8GkZ9a68DpX76LN1a9W9mfPl2GfbDJ9/vzJro6MThNR5qGBH6KkgcK1BziyEzXhHV46Xw==",
 			"license": "MIT",
 			"dependencies": {
 				"react-router": "7.1.0"
@@ -6318,8 +4951,6 @@
 		},
 		"node_modules/read-cache": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
-			"integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
 			"license": "MIT",
 			"dependencies": {
 				"pify": "^2.3.0"
@@ -6327,8 +4958,6 @@
 		},
 		"node_modules/readdirp": {
 			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
 			"license": "MIT",
 			"dependencies": {
 				"picomatch": "^2.2.1"
@@ -6345,8 +4974,6 @@
 		},
 		"node_modules/registry-auth-token": {
 			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
-			"integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6356,8 +4983,6 @@
 		},
 		"node_modules/registry-url": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-			"integrity": "sha512-ZbgR5aZEdf4UKZVBPYIgaglBmSF2Hi94s2PcIHhRGFjKYu+chjJdYfHn4rt3hB6eCKLJ8giVIIfgMa1ehDfZKA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6369,8 +4994,6 @@
 		},
 		"node_modules/require-from-string": {
 			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -6379,8 +5002,6 @@
 		},
 		"node_modules/resolve": {
 			"version": "1.22.10",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-			"integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
 			"license": "MIT",
 			"dependencies": {
 				"is-core-module": "^2.16.0",
@@ -6399,8 +5020,6 @@
 		},
 		"node_modules/reusify": {
 			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
 			"license": "MIT",
 			"engines": {
 				"iojs": ">=1.0.0",
@@ -6409,8 +5028,6 @@
 		},
 		"node_modules/rollup": {
 			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.29.1.tgz",
-			"integrity": "sha512-RaJ45M/kmJUzSWDs1Nnd5DdV4eerC98idtUOVr6FfKcgxqvjwHmxc5upLF9qZU9EpsVzzhleFahrT3shLuJzIw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6448,8 +5065,6 @@
 		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
 			"funding": [
 				{
 					"type": "github",
@@ -6471,15 +5086,11 @@
 		},
 		"node_modules/safe-buffer": {
 			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/scheduler": {
 			"version": "0.23.2",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-			"integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
 			"license": "MIT",
 			"dependencies": {
 				"loose-envify": "^1.1.0"
@@ -6496,8 +5107,6 @@
 		},
 		"node_modules/serve": {
 			"version": "14.2.4",
-			"resolved": "https://registry.npmjs.org/serve/-/serve-14.2.4.tgz",
-			"integrity": "sha512-qy1S34PJ/fcY8gjVGszDB3EXiPSk5FKhUa7tQe0UPRddxRidc2V6cNHPNewbE1D7MAkgLuWEt3Vw56vYy73tzQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6522,8 +5131,6 @@
 		},
 		"node_modules/serve-handler": {
 			"version": "6.1.6",
-			"resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.6.tgz",
-			"integrity": "sha512-x5RL9Y2p5+Sh3D38Fh9i/iQ5ZK+e4xuXRd/pGbM4D13tgo/MGwbttUk8emytcr1YYzBYs+apnUngBDFYfpjPuQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6538,8 +5145,6 @@
 		},
 		"node_modules/serve-handler/node_modules/mime-db": {
 			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -6548,8 +5153,6 @@
 		},
 		"node_modules/serve-handler/node_modules/mime-types": {
 			"version": "2.1.18",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6561,14 +5164,10 @@
 		},
 		"node_modules/set-cookie-parser": {
 			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
-			"integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
 			"license": "MIT"
 		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
 			"license": "MIT",
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
@@ -6579,8 +5178,6 @@
 		},
 		"node_modules/shebang-regex": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -6588,8 +5185,6 @@
 		},
 		"node_modules/signal-exit": {
 			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -6604,8 +5199,6 @@
 		},
 		"node_modules/source-map-js": {
 			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
@@ -6613,8 +5206,6 @@
 		},
 		"node_modules/string-width": {
 			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
 			"license": "MIT",
 			"dependencies": {
 				"eastasianwidth": "^0.2.0",
@@ -6631,8 +5222,6 @@
 		"node_modules/string-width-cjs": {
 			"name": "string-width",
 			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
 			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
@@ -6645,8 +5234,6 @@
 		},
 		"node_modules/string-width-cjs/node_modules/ansi-regex": {
 			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -6654,14 +5241,10 @@
 		},
 		"node_modules/string-width-cjs/node_modules/emoji-regex": {
 			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 			"license": "MIT"
 		},
 		"node_modules/string-width-cjs/node_modules/strip-ansi": {
 			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -6672,8 +5255,6 @@
 		},
 		"node_modules/strip-ansi": {
 			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^6.0.1"
@@ -6688,8 +5269,6 @@
 		"node_modules/strip-ansi-cjs": {
 			"name": "strip-ansi",
 			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -6700,8 +5279,6 @@
 		},
 		"node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
 			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -6709,8 +5286,6 @@
 		},
 		"node_modules/strip-final-newline": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -6719,8 +5294,6 @@
 		},
 		"node_modules/strip-json-comments": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -6729,8 +5302,6 @@
 		},
 		"node_modules/sucrase": {
 			"version": "3.35.0",
-			"resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
-			"integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.2",
@@ -6751,8 +5322,6 @@
 		},
 		"node_modules/supertokens-auth-react": {
 			"version": "0.48.0",
-			"resolved": "https://registry.npmjs.org/supertokens-auth-react/-/supertokens-auth-react-0.48.0.tgz",
-			"integrity": "sha512-JDahnvSKahso6LbD3Oe/e2Ifxz/dg7kMVGnlt+sZbz/kNSQAKk7yaTrxrCemcNDw5IDB9etheCVrLu7ye/ndmQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"intl-tel-input": "^17.0.19",
@@ -6772,14 +5341,10 @@
 		},
 		"node_modules/supertokens-js-override": {
 			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/supertokens-js-override/-/supertokens-js-override-0.0.4.tgz",
-			"integrity": "sha512-r0JFBjkMIdep3Lbk3JA+MpnpuOtw4RSyrlRAbrzMcxwiYco3GFWl/daimQZ5b1forOiUODpOlXbSOljP/oyurg==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/supertokens-web-js": {
 			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/supertokens-web-js/-/supertokens-web-js-0.14.0.tgz",
-			"integrity": "sha512-p4HZ580YX9UYFfY9Sv2VzBQOilqHnNzhrmHlOc45oMxqr/vqvqf+Ih7OXS1lx6RUVmQT8TAsLlFFKIWslIkbHA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -6789,8 +5354,6 @@
 		},
 		"node_modules/supertokens-website": {
 			"version": "20.1.5",
-			"resolved": "https://registry.npmjs.org/supertokens-website/-/supertokens-website-20.1.5.tgz",
-			"integrity": "sha512-2yN42BvHY41/pNIFdJTKSRW3sWZzfOY607i6cY+WWjHSAx7ppMgujyk8tKj+fiQ4MLWCk3HL6QsXZl0zLV4yEw==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -6800,8 +5363,6 @@
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6813,8 +5374,6 @@
 		},
 		"node_modules/supports-preserve-symlinks-flag": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -6824,9 +5383,9 @@
 			}
 		},
 		"node_modules/tailwind-merge": {
-			"version": "2.5.5",
-			"resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.5.5.tgz",
-			"integrity": "sha512-0LXunzzAZzo0tEPxV3I297ffKZPlKDrjj7NXphC8V5ak9yHC5zRmxnOe2m/Rd/7ivsOMJe3JZ2JVocoDdQTRBA==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.0.tgz",
+			"integrity": "sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==",
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -6861,8 +5420,6 @@
 		},
 		"node_modules/tailwindcss": {
 			"version": "3.4.17",
-			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
-			"integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
 			"license": "MIT",
 			"dependencies": {
 				"@alloc/quick-lru": "^5.2.0",
@@ -6898,8 +5455,6 @@
 		},
 		"node_modules/thenify": {
 			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
-			"integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
 			"license": "MIT",
 			"dependencies": {
 				"any-promise": "^1.0.0"
@@ -6907,8 +5462,6 @@
 		},
 		"node_modules/thenify-all": {
 			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-			"integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
 			"license": "MIT",
 			"dependencies": {
 				"thenify": ">= 3.1.0 < 4"
@@ -6919,8 +5472,6 @@
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
 			"license": "MIT",
 			"dependencies": {
 				"is-number": "^7.0.0"
@@ -6931,26 +5482,18 @@
 		},
 		"node_modules/ts-interface-checker": {
 			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
-			"integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/tslib": {
 			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD"
 		},
 		"node_modules/turbo-stream": {
 			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
-			"integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
 			"license": "ISC"
 		},
 		"node_modules/type-fest": {
 			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-			"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
 			"dev": true,
 			"license": "(MIT OR CC0-1.0)",
 			"engines": {
@@ -6962,8 +5505,6 @@
 		},
 		"node_modules/typescript": {
 			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-			"integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -6976,8 +5517,6 @@
 		},
 		"node_modules/update-browserslist-db": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
-			"integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
 			"dev": true,
 			"funding": [
 				{
@@ -7007,8 +5546,6 @@
 		},
 		"node_modules/update-check": {
 			"version": "1.5.4",
-			"resolved": "https://registry.npmjs.org/update-check/-/update-check-1.5.4.tgz",
-			"integrity": "sha512-5YHsflzHP4t1G+8WGPlvKbJEbAJGCgw+Em+dGR1KmBUbr1J36SJBqlHLjR7oob7sco5hWHGQVcr9B2poIVDDTQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7018,8 +5555,6 @@
 		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
@@ -7073,14 +5608,10 @@
 		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"license": "MIT"
 		},
 		"node_modules/vary": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -7089,8 +5620,6 @@
 		},
 		"node_modules/vite": {
 			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-6.0.5.tgz",
-			"integrity": "sha512-akD5IAH/ID5imgue2DYhzsEwCi0/4VKY31uhMLEYJwPP4TiUp8pL5PIK+Wo7H8qT8JY9i+pVfPydcFPYD1EL7g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7161,8 +5690,6 @@
 		},
 		"node_modules/which": {
 			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
 			"license": "ISC",
 			"dependencies": {
 				"isexe": "^2.0.0"
@@ -7176,8 +5703,6 @@
 		},
 		"node_modules/widest-line": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
-			"integrity": "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7192,8 +5717,6 @@
 		},
 		"node_modules/wrap-ansi": {
 			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^6.1.0",
@@ -7210,8 +5733,6 @@
 		"node_modules/wrap-ansi-cjs": {
 			"name": "wrap-ansi",
 			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
@@ -7227,8 +5748,6 @@
 		},
 		"node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
 			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -7236,8 +5755,6 @@
 		},
 		"node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
 			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^2.0.1"
@@ -7251,14 +5768,10 @@
 		},
 		"node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
 			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 			"license": "MIT"
 		},
 		"node_modules/wrap-ansi-cjs/node_modules/string-width": {
 			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
 			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
@@ -7271,8 +5784,6 @@
 		},
 		"node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
 			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -7283,8 +5794,6 @@
 		},
 		"node_modules/yaml": {
 			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
-			"integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
 			"license": "ISC",
 			"bin": {
 				"yaml": "bin.mjs"

--- a/react/package.json
+++ b/react/package.json
@@ -13,7 +13,7 @@
 	},
 	"dependencies": {
 		"@icons-pack/react-simple-icons": "^10.2.0",
-		"@nextui-org/react": "^2.6.8",
+		"@nextui-org/react": "^2.6.10",
 		"framer-motion": "^11.14.4",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",


### PR DESCRIPTION
# Summary

In order to fix the peer dependency reported in https://github.com/nextui-org/nextui/issues/4372, we just need to bump `@nextui-org/react` to the latest version, which is 2.6.10. This allows #589 to move forwards without any issues and a possible upgrade to React 19

## Types of changes

What types of changes does your code introduce to the UC Merced's ACM Chapter Website?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [ ] If code changes were made then they have been tested.
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
