### PR TITLE
Set npm minimum releases to >=24hrs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,6 +21,7 @@
       "schedule": [
         "* 0-3 * * 1"
       ],
+      "minimumReleaseAge": "1 day",
       "automerge": true
     },
     {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,8 @@
+
+# trustLockfile effectively breaks out automated workflows
+# as pnpm will check on each fresh install. We use Renovate to handle
+# our lockfiles, and with proper protections as well. So, this is just annoying
+trustLockfile: true
+
 allowBuilds:
   msw: false


### PR DESCRIPTION
# Summary

pnpm 11.3.0 introduced the [`trustLockfile`](<https://pnpm.io/blog/releases/11.3>) option. By default, it is a good thing, as it prevents tampering from outside folks from messing and installing malicious packages. But, the only people who are editting it will be Renovate and/or me. So, therefore, as it keeps on breaking our workflows, it's best to disable it because we already have branch protections and if a lockfile change is coming from someone else that isn't me or Renovate, then the PR will be rejected.

Also Renovate now gates releases that are less than <=24 hrs from being considered for upgrade.

## Types of changes

What types of changes does your code introduce to the UC Merced's ACM Chapter Website?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
