### PR TITLE
Fix first-login TypeError on freshly seeded accounts

### DIFF
--- a/src/routes/dashboard/index.tsx
+++ b/src/routes/dashboard/index.tsx
@@ -96,7 +96,7 @@ export const memberEventsQueryOptions = (filter: "attended" | "planned") =>
   });
 
 export const eventsListQueryOptions = queryOptions({
-  queryKey: ["events", "list", {}],
+  queryKey: ["events", "dashboard-list"],
   queryFn: async () => {
     const fetchPage = (page: number) =>
       axios.get<KanaePage<FullEvent>>(`${API_BASE_URL}/events`, {


### PR DESCRIPTION
# Summary

When a freshly seeded user logs into the dashboard for the first time, we get this error:

```
TypeError: (events ?? []).map is not a function
    at DashboardHome (index.tsx:192:53)
    at Object.react_stack_bottom_frame (react-dom_client.js?v=051dd9c8:12864:12)
    at renderWithHooks (react-dom_client.js?v=051dd9c8:4211:19)
    at updateFunctionComponent (react-dom_client.js?v=051dd9c8:5567:16)
    at beginWork (react-dom_client.js?v=051dd9c8:6138:20)
    at runWithFiberInDEV (react-dom_client.js?v=051dd9c8:850:66)
    at performUnitOfWork (react-dom_client.js?v=051dd9c8:8427:92)
    at workLoopSync (react-dom_client.js?v=051dd9c8:8323:37)
    at renderRootSync (react-dom_client.js?v=051dd9c8:8307:6)
    at performWorkOnRoot (react-dom_client.js?v=051dd9c8:7992:27)

The above error occurred in the <DashboardHome> component.

React will try to recreate this component tree from scratch using the error boundary you provided, CatchBoundaryImpl.
```

Turns out three different Tanstack queries shared the same query key. Namely in `src/routes/index.tsx:164-185`, `src/routes/events.tsx:190-215`, and `src/routes/dashboard/index.tsx:99`. It all resolves down to `["events", "list" ,{}]`. It firsts run the index query, which gives `{ data: [...], total: n }`. And then the dahsboard query does a prefetch, and ends up using the cached content of `{ data: [...], total: n }`; which is the wrong shape and result. Dashboard query expects `[{...}]`, not `{ data: [...], total: n }`, thus causing a crash. Reloading works because it force wipes the cache, and the dashboard query result takes over in the cache.

We'll also probably removed the old shared queries that inject the staleTime and other options as the routes require Kanae to be up regardless - we can't really "fake" it.

## Types of changes

What types of changes does your code introduce to the UC Merced's ACM Chapter Website?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
