### PR TITLE
Remove shared query options for dashboard routes

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,7 +8,13 @@ import ReactDOM from "react-dom/client";
 
 axios.defaults.withCredentials = true;
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 60_000,
+    },
+  },
+});
 
 // Create a new router instance
 const router = createRouter({

--- a/src/routes/dashboard/admin/members.tsx
+++ b/src/routes/dashboard/admin/members.tsx
@@ -288,14 +288,6 @@ const CARD_CLASS =
   "rounded-[18px] border border-border bg-card shadow-[0px_4px_14px_rgba(112,144,176,0.14)] dark:shadow-[0px_4px_14px_rgba(0,0,0,0.4)]";
 const TEAL_BUTTON_CLASS = "bg-brand-teal font-bold text-primary hover:bg-brand-teal/85";
 
-const SHARED_QUERY_OPTIONS = {
-  staleTime: 60_000,
-  retry: false,
-  refetchOnWindowFocus: false,
-  refetchOnReconnect: false,
-  refetchOnMount: false,
-} as const;
-
 /// Tanstack Query options
 
 const membersQueryOptions = queryOptions({
@@ -319,7 +311,6 @@ const membersQueryOptions = queryOptions({
     }
     return members;
   },
-  ...SHARED_QUERY_OPTIONS,
 });
 
 /// Helper functions

--- a/src/routes/dashboard/admin/overview.tsx
+++ b/src/routes/dashboard/admin/overview.tsx
@@ -110,14 +110,6 @@ const EVENTS_PAGE_SIZE = 50;
 const CARD_CLASS =
   "rounded-[18px] border border-border bg-card shadow-[0px_4px_14px_rgba(112,144,176,0.14)] dark:shadow-[0px_4px_14px_rgba(0,0,0,0.4)]";
 
-const SHARED_QUERY_OPTIONS = {
-  staleTime: 60_000,
-  retry: false,
-  refetchOnWindowFocus: false,
-  refetchOnReconnect: false,
-  refetchOnMount: false,
-} as const;
-
 /// Tanstack Query options
 
 const overviewMembersQueryOptions = queryOptions({
@@ -139,7 +131,6 @@ const overviewMembersQueryOptions = queryOptions({
     }
     return members;
   },
-  ...SHARED_QUERY_OPTIONS,
 });
 
 const overviewProjectsQueryOptions = queryOptions({
@@ -156,7 +147,6 @@ const overviewProjectsQueryOptions = queryOptions({
     }
     return projects.filter((project) => project.active).length;
   },
-  ...SHARED_QUERY_OPTIONS,
 });
 
 const overviewEventsQueryOptions = queryOptions({
@@ -174,7 +164,6 @@ const overviewEventsQueryOptions = queryOptions({
     }
     return events.filter((event) => !isPastEvent(event, now)).length;
   },
-  ...SHARED_QUERY_OPTIONS,
 });
 
 const overviewTagsQueryOptions = queryOptions({
@@ -184,7 +173,6 @@ const overviewTagsQueryOptions = queryOptions({
     const { data } = await axios.get<unknown[]>(`${API_BASE_URL}/tags`);
     return data.length;
   },
-  ...SHARED_QUERY_OPTIONS,
 });
 
 /// Route components

--- a/src/routes/dashboard/admin/tags.tsx
+++ b/src/routes/dashboard/admin/tags.tsx
@@ -215,14 +215,6 @@ const FIELD_ERROR_CLASS = "text-[12px] font-semibold text-[#e13737] dark:text-[#
 const TAG_PILL_CLASS =
   "inline-flex items-center rounded-full border border-border bg-muted px-2 py-0.5 text-[11px] font-semibold text-brand-text-sub";
 
-const SHARED_QUERY_OPTIONS = {
-  staleTime: 60_000,
-  retry: false,
-  refetchOnWindowFocus: false,
-  refetchOnReconnect: false,
-  refetchOnMount: false,
-} as const;
-
 /// Zod schema
 
 const tagFormSchema = z.object({
@@ -242,7 +234,6 @@ const tagsQueryOptions = queryOptions({
     const { data } = await axios.get<FullTags[]>(`${API_BASE_URL}/tags`);
     return data;
   },
-  ...SHARED_QUERY_OPTIONS,
 });
 
 /// Helper functions

--- a/src/routes/dashboard/events.tsx
+++ b/src/routes/dashboard/events.tsx
@@ -126,14 +126,6 @@ const API_BASE_URL =
   (import.meta.env.VITE_API_URL as string | undefined) ?? "http://localhost:8000";
 const EVENTS_VIEWS: EventView[] = ["calendar", "grid", "list"];
 
-const SHARED_QUERY_OPTIONS = {
-  staleTime: 60_000,
-  retry: false,
-  refetchOnWindowFocus: false,
-  refetchOnReconnect: false,
-  refetchOnMount: false,
-} as const;
-
 /// Tanstack Query options
 
 const memberQueryOptions = (memberId: string) =>
@@ -145,7 +137,6 @@ const memberQueryOptions = (memberId: string) =>
       );
       return data;
     },
-    ...SHARED_QUERY_OPTIONS,
   });
 
 const eventAttendanceCodeQueryOptions = (eventId: string) =>
@@ -157,7 +148,6 @@ const eventAttendanceCodeQueryOptions = (eventId: string) =>
       );
       return data;
     },
-    ...SHARED_QUERY_OPTIONS,
   });
 
 const eventAttendanceQueryOptions = (eventId: string) =>
@@ -170,7 +160,6 @@ const eventAttendanceQueryOptions = (eventId: string) =>
       );
       return data;
     },
-    ...SHARED_QUERY_OPTIONS,
   });
 
 /// Route components

--- a/src/routes/dashboard/events_.past.tsx
+++ b/src/routes/dashboard/events_.past.tsx
@@ -44,14 +44,6 @@ const API_BASE_URL =
   (import.meta.env.VITE_API_URL as string | undefined) ?? "http://localhost:8000";
 const PAST_VIEWS: EventView[] = ["list", "grid"];
 
-const SHARED_QUERY_OPTIONS = {
-  staleTime: 60_000,
-  retry: false,
-  refetchOnWindowFocus: false,
-  refetchOnReconnect: false,
-  refetchOnMount: false,
-} as const;
-
 /// Tanstack Query options
 
 const memberQueryOptions = (memberId: string) =>
@@ -63,7 +55,6 @@ const memberQueryOptions = (memberId: string) =>
       );
       return data;
     },
-    ...SHARED_QUERY_OPTIONS,
   });
 
 function DashboardPastEvents() {

--- a/src/routes/dashboard/index.tsx
+++ b/src/routes/dashboard/index.tsx
@@ -72,14 +72,6 @@ const TEAL_BUTTON_CLASS =
 const RAIL_CLASS =
   "rounded-[20px] border border-border bg-card p-4 shadow-[0px_4px_14px_rgba(112,144,176,0.14)] dark:shadow-[0px_4px_14px_rgba(0,0,0,0.4)]";
 
-const SHARED_QUERY_OPTIONS = {
-  staleTime: 60_000,
-  retry: false,
-  refetchOnWindowFocus: false,
-  refetchOnReconnect: false,
-  refetchOnMount: false,
-} as const;
-
 /// Tanstack Query options
 
 export const memberEventsQueryOptions = (filter: "attended" | "planned") =>
@@ -92,7 +84,6 @@ export const memberEventsQueryOptions = (filter: "attended" | "planned") =>
       return data;
     },
     select: (events: FullEvent[]) => new Set(events.map((event) => event.id)),
-    ...SHARED_QUERY_OPTIONS,
   });
 
 export const eventsListQueryOptions = queryOptions({
@@ -114,7 +105,6 @@ export const eventsListQueryOptions = queryOptions({
     }
     return events;
   },
-  ...SHARED_QUERY_OPTIONS,
 });
 
 export const meQueryOptions = queryOptions({
@@ -123,7 +113,6 @@ export const meQueryOptions = queryOptions({
     const { data } = await axios.get<ClientMember>(`${API_BASE_URL}/members/me`);
     return data;
   },
-  ...SHARED_QUERY_OPTIONS,
 });
 
 export const plannedEventsQueryOptions = memberEventsQueryOptions("planned");

--- a/src/routes/dashboard/manage/events.tsx
+++ b/src/routes/dashboard/manage/events.tsx
@@ -312,14 +312,6 @@ const FACT_LABEL_CLASS =
   "mb-1 text-[10.5px] font-bold tracking-[0.06em] text-muted-foreground uppercase";
 const FACT_VALUE_CLASS = "text-[13.5px] font-bold text-foreground";
 
-const SHARED_QUERY_OPTIONS = {
-  staleTime: 60_000,
-  retry: false,
-  refetchOnWindowFocus: false,
-  refetchOnReconnect: false,
-  refetchOnMount: false,
-} as const;
-
 /// Zod schema
 
 const eventFormSchema = z
@@ -367,7 +359,6 @@ const manageEventsQueryOptions = queryOptions({
     }
     return events;
   },
-  ...SHARED_QUERY_OPTIONS,
 });
 
 const eventAttendanceQueryOptions = (eventId: string) =>
@@ -380,7 +371,6 @@ const eventAttendanceQueryOptions = (eventId: string) =>
       );
       return data;
     },
-    ...SHARED_QUERY_OPTIONS,
   });
 
 const eventAttendanceCodeQueryOptions = (eventId: string) =>
@@ -392,7 +382,6 @@ const eventAttendanceCodeQueryOptions = (eventId: string) =>
       );
       return data;
     },
-    ...SHARED_QUERY_OPTIONS,
   });
 
 /// Helper functions

--- a/src/routes/dashboard/manage/projects.tsx
+++ b/src/routes/dashboard/manage/projects.tsx
@@ -392,14 +392,6 @@ const FACT_VALUE_CLASS = "text-[13.5px] font-bold text-foreground";
 const FIELD_ERROR_CLASS = "text-[12px] font-semibold text-[#e13737] dark:text-[#ff6b6b]";
 const MONTH_YEAR_FMT = new Intl.DateTimeFormat("en-US", { month: "short", year: "numeric" });
 
-const SHARED_QUERY_OPTIONS = {
-  staleTime: 60_000,
-  retry: false,
-  refetchOnWindowFocus: false,
-  refetchOnReconnect: false,
-  refetchOnMount: false,
-} as const;
-
 /// Zod schema
 
 const projectFormSchema = z.object({
@@ -437,7 +429,6 @@ const manageProjectsQueryOptions = ({ active, name, page }: ProjectPageParams) =
       return data;
     },
     placeholderData: keepPreviousData,
-    ...SHARED_QUERY_OPTIONS,
   });
 
 const memberDirectoryQueryOptions = (query: string) =>
@@ -454,7 +445,6 @@ const memberDirectoryQueryOptions = (query: string) =>
       return data.data ?? EMPTY_MEMBERS;
     },
     placeholderData: keepPreviousData,
-    ...SHARED_QUERY_OPTIONS,
   });
 
 const manageInvitesQueryOptions = queryOptions({
@@ -465,7 +455,6 @@ const manageInvitesQueryOptions = queryOptions({
     });
     return data;
   },
-  ...SHARED_QUERY_OPTIONS,
 });
 
 /// Helper functions

--- a/src/routes/dashboard/projects.tsx
+++ b/src/routes/dashboard/projects.tsx
@@ -247,14 +247,6 @@ const FACT_LABEL_CLASS =
 const FACT_VALUE_CLASS = "text-[13.5px] font-bold text-foreground";
 const MONTH_YEAR_FMT = new Intl.DateTimeFormat("en-US", { month: "short", year: "numeric" });
 
-const SHARED_QUERY_OPTIONS = {
-  staleTime: 60_000,
-  retry: false,
-  refetchOnWindowFocus: false,
-  refetchOnReconnect: false,
-  refetchOnMount: false,
-} as const;
-
 /// Tanstack Query options
 
 export const projectsQueryOptions = queryOptions({
@@ -265,7 +257,6 @@ export const projectsQueryOptions = queryOptions({
     });
     return data.data;
   },
-  ...SHARED_QUERY_OPTIONS,
 });
 
 const memberProjectsQueryOptions = queryOptions({
@@ -275,7 +266,6 @@ const memberProjectsQueryOptions = queryOptions({
     return data;
   },
   select: (projects: MemberProject[]) => new Set(projects.map((project) => project.id)),
-  ...SHARED_QUERY_OPTIONS,
 });
 
 const projectInvitesQueryOptions = queryOptions({
@@ -287,7 +277,6 @@ const projectInvitesQueryOptions = queryOptions({
     );
     return data;
   },
-  ...SHARED_QUERY_OPTIONS,
 });
 
 export const projectMediaQueryOptions = (projectId: string) =>
@@ -299,7 +288,6 @@ export const projectMediaQueryOptions = (projectId: string) =>
       );
       return data;
     },
-    ...SHARED_QUERY_OPTIONS,
   });
 
 /// Helper functions

--- a/src/routes/dashboard/route.tsx
+++ b/src/routes/dashboard/route.tsx
@@ -255,14 +255,6 @@ const SIDEBAR_STYLE = {
   "--sidebar-width-icon": "3.5rem",
 } as CSSProperties;
 
-const SHARED_QUERY_OPTIONS = {
-  staleTime: 60_000,
-  retry: false,
-  refetchOnWindowFocus: false,
-  refetchOnReconnect: false,
-  refetchOnMount: false,
-} as const;
-
 const OPEN_SETTINGS = (): { settings: "profile" } => ({ settings: "profile" });
 const SETTINGS_MASK = { to: "/dashboard/settings" } as const;
 const BLANK_DELETE_FORM = { email: "" };
@@ -336,7 +328,6 @@ export const meQueryOptions = queryOptions({
     const { data } = await axios.get<ClientMember>(`${API_BASE_URL}/members/me`);
     return data;
   },
-  ...SHARED_QUERY_OPTIONS,
 });
 
 export const sudoQueryOptions = queryOptions({
@@ -345,7 +336,6 @@ export const sudoQueryOptions = queryOptions({
     const { data } = await axios.get<Sudo>(`${API_BASE_URL}/sudo`);
     return data;
   },
-  ...SHARED_QUERY_OPTIONS,
 });
 
 export const settingsFlowQueryOptions = queryOptions({
@@ -353,7 +343,6 @@ export const settingsFlowQueryOptions = queryOptions({
   queryFn: async () => {
     return await oryInit("settings", {});
   },
-  ...SHARED_QUERY_OPTIONS,
 });
 
 /// Helper functions


### PR DESCRIPTION
# Summary

This is mostly to centralize changes and to prepare for more actual app usage as most features are now implemented and done. Note that `staleTime` is now put on the default option to keep the snappness of the UI and prefetch queries.

## Types of changes

What types of changes does your code introduce to the UC Merced's ACM Chapter Website?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [x] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
