### PR TITLE
Install `pnpm` via alternative means instead of corepack

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,9 @@ ENV PATH="$PNPM_HOME:$PATH"
 
 WORKDIR /website
 
-RUN npm install -g pnpm@latest
+RUN npm install -g pnpm@11.20.0 \
+    --ignore-scripts --no-fund --no-update-notifier \
+    > /dev/null
 
 # Install dependencies first (cached unless manifests change)
 COPY package.json pnpm-lock.yaml /website/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ ENV PATH="$PNPM_HOME:$PATH"
 
 WORKDIR /website
 
-RUN corepack enable
+RUN npm install -g pnpm@latest
 
 # Install dependencies first (cached unless manifests change)
 COPY package.json pnpm-lock.yaml /website/


### PR DESCRIPTION
# Summary

Corepack isn't going to be installed by default in Node.js 25+, and as the next LTS release is 26, this is a change that needs to be done in order to ensure a smooth upgrade.

## Types of changes

What types of changes does your code introduce to the UC Merced's ACM Chapter Website?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [x] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
