### PR TITLE
Add dialogs and details for events

### DIFF
--- a/src/components/app/attendance-dialog.tsx
+++ b/src/components/app/attendance-dialog.tsx
@@ -1,0 +1,191 @@
+import { queryOptions, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+
+import { CheckInPanel } from "@/components/app/check-in-panel";
+import { RosterRow } from "@/components/app/dashboard-events";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  type AttendanceMember,
+  type FullEvent,
+  type KanaePage,
+  determineCheckIn,
+  fmtClock,
+} from "@/lib/dashboard-events";
+
+/// Types & interfaces
+
+interface AttendanceDialogProps {
+  event: FullEvent;
+  now: Date;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/// Constants
+
+const API_BASE_URL =
+  (import.meta.env.VITE_API_URL as string | undefined) ?? "http://localhost:8000";
+const ROSTER_STAT_CLASS =
+  "flex-1 rounded-xl border border-border bg-card px-3.5 py-3 shadow-[0px_2px_5px_rgba(112,144,176,0.12)] dark:shadow-[0px_2px_5px_rgba(0,0,0,0.3)]";
+
+/// Tanstack Query options
+
+const eventAttendanceCodeQueryOptions = (eventId: string) =>
+  queryOptions({
+    queryKey: ["events", eventId, "attendance-code"],
+    queryFn: async () => {
+      const { data } = await axios.get<{ code: string }>(
+        `${API_BASE_URL}/events/${eventId}/attendance-code`,
+      );
+      return data;
+    },
+  });
+
+const eventAttendanceQueryOptions = (eventId: string) =>
+  queryOptions({
+    queryKey: ["events", eventId, "attendance"],
+    queryFn: async () => {
+      const { data } = await axios.get<KanaePage<AttendanceMember>>(
+        `${API_BASE_URL}/events/${eventId}/attendance`,
+        { params: { page: 1, size: 100 } },
+      );
+      return data;
+    },
+  });
+
+/// AttendanceDialog
+
+export function AttendanceDialog({
+  event,
+  now,
+  open,
+  onOpenChange,
+}: Readonly<AttendanceDialogProps>) {
+  const queryClient = useQueryClient();
+
+  const [rosterTab, setRosterTab] = useState<"qr" | "roster">("qr");
+  const [copied, setCopied] = useState(false);
+
+  const codeQuery = useQuery({
+    ...eventAttendanceCodeQueryOptions(event.id),
+    enabled: rosterTab === "qr",
+  });
+  const rosterQuery = useQuery({
+    ...eventAttendanceQueryOptions(event.id),
+    enabled: rosterTab === "roster",
+  });
+
+  const { mutate: undoCheckin, isPending: isUndoing } = useMutation({
+    mutationFn: async (memberId: string) => {
+      await axios.delete(`${API_BASE_URL}/events/${event.id}/attendance/${memberId}`);
+    },
+    onError: () => toast.error("Couldn't undo the check-in. Please try again."),
+    onSuccess: () => toast.success("Check-in undone."),
+    onSettled: () =>
+      queryClient.invalidateQueries({ queryKey: eventAttendanceQueryOptions(event.id).queryKey }),
+  });
+
+  const code = (codeQuery.data?.code ?? "").slice(0, 8);
+  const copyCode = useCallback(() => {
+    navigator.clipboard
+      .writeText(code)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => {
+          setCopied(false);
+        }, 1800);
+      })
+      .catch(() => {
+        toast.error("Couldn't copy the code.");
+      });
+  }, [code]);
+
+  const rosterMembers = rosterQuery.data?.data ?? [];
+  const plannedCount = rosterMembers.filter((member) => member.planned).length;
+  const attendedCount = rosterMembers.filter((member) => member.attended).length;
+  const checkIn = determineCheckIn(event, now);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[88svh] gap-4 overflow-y-auto sm:max-w-135">
+        <DialogHeader>
+          <DialogTitle className="text-lg font-extrabold">Attendance</DialogTitle>
+          <DialogDescription>{event.name}</DialogDescription>
+        </DialogHeader>
+
+        <Tabs value={rosterTab} onValueChange={setRosterTab} className="gap-4">
+          <TabsList className="h-10 w-full border border-border">
+            <TabsTrigger value="qr" className="font-bold data-active:border-border">
+              Check-in QR
+            </TabsTrigger>
+            <TabsTrigger value="roster" className="font-bold data-active:border-border">
+              Roster · {String(rosterMembers.length)}
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="qr" className="flex flex-col items-center gap-4.5">
+            <CheckInPanel
+              code={code}
+              copied={copied}
+              onCopy={copyCode}
+              state={checkIn}
+              closesAt={fmtClock(event.end_at, event.timezone)}
+            />
+          </TabsContent>
+
+          <TabsContent value="roster" className="flex flex-col gap-3">
+            <div className="flex gap-3">
+              <div className={ROSTER_STAT_CLASS}>
+                <div className="text-2xl leading-none font-extrabold text-brand-sky">
+                  {String(plannedCount)}
+                </div>
+                <div className="mt-1 text-xs font-semibold text-muted-foreground">
+                  Planned (RSVP'd)
+                </div>
+              </div>
+              <div className={ROSTER_STAT_CLASS}>
+                <div className="text-2xl leading-none font-extrabold text-[#15a66e] dark:text-[#3fd68c]">
+                  {String(attendedCount)}
+                </div>
+                <div className="mt-1 text-xs font-semibold text-muted-foreground">Attended</div>
+              </div>
+            </div>
+            <div className="-mx-2 flex max-h-72 flex-col gap-2 overflow-y-auto p-2">
+              {rosterQuery.isPending && (
+                <p className="px-2 py-6 text-center text-sm text-muted-foreground">
+                  Loading roster…
+                </p>
+              )}
+              {!rosterQuery.isPending && rosterMembers.length === 0 && (
+                <p className="px-2 py-6 text-center text-sm text-muted-foreground">
+                  No attendees yet.
+                </p>
+              )}
+              {rosterMembers.map((member) => (
+                <RosterRow
+                  key={member.id}
+                  member={member}
+                  disabled={isUndoing}
+                  onUndo={undoCheckin}
+                />
+              ))}
+            </div>
+            <p className="text-[11.5px]/relaxed text-muted-foreground">
+              Undo clears a member's attended flag but keeps their RSVP — for correcting a mistaken
+              check-in.
+            </p>
+          </TabsContent>
+        </Tabs>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/app/dashboard-events.tsx
+++ b/src/components/app/dashboard-events.tsx
@@ -7,11 +7,15 @@ import {
   LayoutGrid,
   List,
   MapPin,
+  MinusCircle,
+  MoreHorizontal,
   QrCode,
+  RotateCcw,
   ScanLine,
   Search,
   Ticket,
   User,
+  UserPlus,
   X,
 } from "lucide-react";
 import {
@@ -32,6 +36,12 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -43,6 +53,7 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
+  type AttendanceMember,
   type DashboardEvent,
   type EventType,
   type EventView,
@@ -59,6 +70,8 @@ import {
 import { cn } from "@/lib/utils";
 
 /// Types & interfaces
+
+type RosterStatus = "checked_in" | "expected" | "no_show" | "walk_in";
 
 export interface EventCallbacks {
   onOpen?: (event: DashboardEvent) => void;
@@ -100,12 +113,40 @@ const LONG_DATE_OPTIONS: Intl.DateTimeFormatOptions = {
   day: "numeric",
 };
 
+const ROSTER_STATUS = {
+  checked_in: {
+    label: "Checked in",
+    icon: Check,
+    className: "bg-[#15a66e]/15 text-[#15a66e] dark:text-[#3fd68c]",
+  },
+  walk_in: {
+    label: "Walk-in",
+    icon: UserPlus,
+    className: "bg-[#f7b731]/18 text-[#a06d00] dark:text-[#ffd56b]",
+  },
+  expected: {
+    label: "Expected",
+    icon: Clock,
+    className: "bg-brand-sky/15 text-brand-sky-text",
+  },
+  no_show: {
+    label: "No-show",
+    icon: MinusCircle,
+    className: "bg-muted text-muted-foreground",
+  },
+} satisfies Record<RosterStatus, { className: string; icon: LucideIcon; label: string }>;
+
 /// Helpers
 
 function eventStateMeta(event: DashboardEvent, now: Date): StateMeta {
   if (event.attended) return STATE_ATTENDED;
   if (isPastEvent(event, now)) return event.planned ? STATE_MISSED : STATE_ENDED;
   return event.planned ? STATE_GOING : STATE_OPEN;
+}
+
+function getRosterStatus(member: AttendanceMember): RosterStatus {
+  if (member.attended) return member.planned ? "checked_in" : "walk_in";
+  return member.planned ? "expected" : "no_show";
 }
 
 /// EventTypeChip
@@ -857,5 +898,69 @@ export function EventDetailDialog({
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  );
+}
+
+/// RosterRow
+
+export function RosterRow({
+  disabled,
+  member,
+  onUndo,
+}: Readonly<{
+  disabled: boolean;
+  member: AttendanceMember;
+  onUndo: (memberId: string) => void;
+}>) {
+  const handleUndo = useCallback(() => {
+    onUndo(member.id);
+  }, [member.id, onUndo]);
+
+  const status = ROSTER_STATUS[getRosterStatus(member)];
+  const initials =
+    member.name
+      .match(/\S+/g)
+      ?.slice(0, 2)
+      .map((part) => part[0])
+      .join("")
+      .toUpperCase() ?? "··";
+
+  const StatusIcon = status.icon;
+
+  return (
+    <div className="flex items-center gap-3 rounded-xl border border-border bg-card px-3.5 py-2.5 shadow-[0px_2px_5px_rgba(112,144,176,0.12)] dark:shadow-[0px_2px_5px_rgba(0,0,0,0.3)]">
+      <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-brand-sky/15 text-[12px] font-extrabold text-brand-sky-text">
+        {initials}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm font-bold text-foreground">{member.name}</div>
+      </div>
+      <span
+        className={cn(
+          "inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11.5px] font-bold",
+          status.className,
+        )}
+      >
+        <StatusIcon className="size-3.5" />
+        {status.label}
+      </span>
+      {member.attended && (
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={<Button variant="ghost" size="icon-sm" />}
+            title="Member actions"
+            aria-label="Member actions"
+          >
+            <MoreHorizontal />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-auto">
+            <DropdownMenuItem disabled={disabled} onClick={handleUndo}>
+              <RotateCcw />
+              Undo check-in
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+    </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -187,6 +187,7 @@
   }
   html {
     @apply scroll-smooth font-sans;
+    scrollbar-gutter: stable;
   }
 }
 

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -23,6 +23,7 @@ import { Route as DashboardIndexRouteImport } from './routes/dashboard/index'
 import { Route as DashboardEventsRouteImport } from './routes/dashboard/events'
 import { Route as DashboardProjectsRouteImport } from './routes/dashboard/projects'
 import { Route as DashboardSettingsRouteImport } from './routes/dashboard/settings'
+import { Route as EventEventIdRouteImport } from './routes/event/$eventId'
 import { Route as ProjectProjectIdRouteImport } from './routes/project/$projectId'
 import { Route as DashboardAdminMembersRouteImport } from './routes/dashboard/admin/members'
 import { Route as DashboardAdminOverviewRouteImport } from './routes/dashboard/admin/overview'
@@ -102,6 +103,11 @@ const DashboardSettingsRoute = DashboardSettingsRouteImport.update({
   path: '/settings',
   getParentRoute: () => DashboardRouteRoute,
 } as any)
+const EventEventIdRoute = EventEventIdRouteImport.update({
+  id: '/event/$eventId',
+  path: '/event/$eventId',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ProjectProjectIdRoute = ProjectProjectIdRouteImport.update({
   id: '/project/$projectId',
   path: '/project/$projectId',
@@ -158,6 +164,7 @@ export interface FileRoutesByFullPath {
   '/dashboard/events': typeof DashboardEventsRoute
   '/dashboard/projects': typeof DashboardProjectsRoute
   '/dashboard/settings': typeof DashboardSettingsRoute
+  '/event/$eventId': typeof EventEventIdRoute
   '/project/$projectId': typeof ProjectProjectIdRoute
   '/dashboard/': typeof DashboardIndexRoute
   '/dashboard/admin/members': typeof DashboardAdminMembersRoute
@@ -181,6 +188,7 @@ export interface FileRoutesByTo {
   '/dashboard/events': typeof DashboardEventsRoute
   '/dashboard/projects': typeof DashboardProjectsRoute
   '/dashboard/settings': typeof DashboardSettingsRoute
+  '/event/$eventId': typeof EventEventIdRoute
   '/project/$projectId': typeof ProjectProjectIdRoute
   '/dashboard': typeof DashboardIndexRoute
   '/dashboard/admin/members': typeof DashboardAdminMembersRoute
@@ -206,6 +214,7 @@ export interface FileRoutesById {
   '/dashboard/events': typeof DashboardEventsRoute
   '/dashboard/projects': typeof DashboardProjectsRoute
   '/dashboard/settings': typeof DashboardSettingsRoute
+  '/event/$eventId': typeof EventEventIdRoute
   '/project/$projectId': typeof ProjectProjectIdRoute
   '/dashboard/': typeof DashboardIndexRoute
   '/dashboard/admin/members': typeof DashboardAdminMembersRoute
@@ -232,6 +241,7 @@ export interface FileRouteTypes {
     | '/dashboard/events'
     | '/dashboard/projects'
     | '/dashboard/settings'
+    | '/event/$eventId'
     | '/project/$projectId'
     | '/dashboard/'
     | '/dashboard/admin/members'
@@ -255,6 +265,7 @@ export interface FileRouteTypes {
     | '/dashboard/events'
     | '/dashboard/projects'
     | '/dashboard/settings'
+    | '/event/$eventId'
     | '/project/$projectId'
     | '/dashboard'
     | '/dashboard/admin/members'
@@ -279,6 +290,7 @@ export interface FileRouteTypes {
     | '/dashboard/events'
     | '/dashboard/projects'
     | '/dashboard/settings'
+    | '/event/$eventId'
     | '/project/$projectId'
     | '/dashboard/'
     | '/dashboard/admin/members'
@@ -301,6 +313,7 @@ export interface RootRouteChildren {
   RecoveryRoute: typeof RecoveryRoute
   RegisterRoute: typeof RegisterRoute
   SigsRoute: typeof SigsRoute
+  EventEventIdRoute: typeof EventEventIdRoute
   ProjectProjectIdRoute: typeof ProjectProjectIdRoute
 }
 
@@ -403,6 +416,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/dashboard/settings'
       preLoaderRoute: typeof DashboardSettingsRouteImport
       parentRoute: typeof DashboardRouteRoute
+    }
+    '/event/$eventId': {
+      id: '/event/$eventId'
+      path: '/event/$eventId'
+      fullPath: '/event/$eventId'
+      preLoaderRoute: typeof EventEventIdRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/project/$projectId': {
       id: '/project/$projectId'
@@ -507,6 +527,7 @@ const rootRouteChildren: RootRouteChildren = {
   RecoveryRoute: RecoveryRoute,
   RegisterRoute: RegisterRoute,
   SigsRoute: SigsRoute,
+  EventEventIdRoute: EventEventIdRoute,
   ProjectProjectIdRoute: ProjectProjectIdRoute,
 }
 export const routeTree = rootRouteImport

--- a/src/routes/dashboard/events.tsx
+++ b/src/routes/dashboard/events.tsx
@@ -9,43 +9,17 @@ import type { CalendarType } from "@schedule-x/calendar";
 import { queryOptions, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import axios from "axios";
-import {
-  type LucideIcon,
-  Check,
-  Clock,
-  MapPin,
-  MinusCircle,
-  MoreHorizontal,
-  RotateCcw,
-  ScanLine,
-  UserPlus,
-} from "lucide-react";
+import { Clock, MapPin, ScanLine } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 import { toast } from "sonner";
 
+import { AttendanceDialog } from "@/components/app/attendance-dialog";
 import { CheckInDialog } from "@/components/app/check-in-dialog";
-import { CheckInPanel } from "@/components/app/check-in-panel";
 import { EventDetailDialog, EventResults, EventToolbar } from "@/components/app/dashboard-events";
 import { ManageEventsCalendar } from "@/components/app/events-calendar";
 import { Button } from "@/components/ui/button";
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import {
-  type AttendanceMember,
   type DashboardEvent,
-  type KanaePage,
   type EventType,
   type EventView,
   type FullEvent,
@@ -71,10 +45,6 @@ export const Route = createFileRoute("/dashboard/events")({
   },
 });
 
-/// Types and Interfaces
-
-type RosterStatus = "checked_in" | "expected" | "no_show" | "walk_in";
-
 // Constants
 
 const EVENT_CALENDARS: Record<string, CalendarType> = Object.fromEntries(
@@ -99,29 +69,6 @@ const EVENT_CALENDARS: Record<string, CalendarType> = Object.fromEntries(
   }),
 );
 
-const ROSTER_STATUS = {
-  checked_in: {
-    label: "Checked in",
-    icon: Check,
-    className: "bg-[#15a66e]/15 text-[#15a66e] dark:text-[#3fd68c]",
-  },
-  walk_in: {
-    label: "Walk-in",
-    icon: UserPlus,
-    className: "bg-[#f7b731]/18 text-[#a06d00] dark:text-[#ffd56b]",
-  },
-  expected: {
-    label: "Expected",
-    icon: Clock,
-    className: "bg-brand-sky/15 text-brand-sky-text",
-  },
-  no_show: {
-    label: "No-show",
-    icon: MinusCircle,
-    className: "bg-muted text-muted-foreground",
-  },
-} satisfies Record<RosterStatus, { className: string; icon: LucideIcon; label: string }>;
-
 const API_BASE_URL =
   (import.meta.env.VITE_API_URL as string | undefined) ?? "http://localhost:8000";
 const EVENTS_VIEWS: EventView[] = ["calendar", "grid", "list"];
@@ -139,97 +86,7 @@ const memberQueryOptions = (memberId: string) =>
     },
   });
 
-const eventAttendanceCodeQueryOptions = (eventId: string) =>
-  queryOptions({
-    queryKey: ["events", eventId, "attendance-code"],
-    queryFn: async () => {
-      const { data } = await axios.get<{ code: string }>(
-        `${API_BASE_URL}/events/${eventId}/attendance-code`,
-      );
-      return data;
-    },
-  });
-
-const eventAttendanceQueryOptions = (eventId: string) =>
-  queryOptions({
-    queryKey: ["events", eventId, "attendance"],
-    queryFn: async () => {
-      const { data } = await axios.get<KanaePage<AttendanceMember>>(
-        `${API_BASE_URL}/events/${eventId}/attendance`,
-        { params: { page: 1, size: 100 } },
-      );
-      return data;
-    },
-  });
-
 /// Route components
-
-function getRosterStatus(member: AttendanceMember): RosterStatus {
-  if (member.attended) return member.planned ? "checked_in" : "walk_in";
-  return member.planned ? "expected" : "no_show";
-}
-
-export function RosterRow({
-  disabled,
-  member,
-  onUndo,
-}: Readonly<{
-  disabled: boolean;
-  member: AttendanceMember;
-  onUndo: (memberId: string) => void;
-}>) {
-  const handleUndo = useCallback(() => {
-    onUndo(member.id);
-  }, [member.id, onUndo]);
-
-  const status = ROSTER_STATUS[getRosterStatus(member)];
-  const initials =
-    member.name
-      .match(/\S+/g)
-      ?.slice(0, 2)
-      .map((part) => part[0])
-      .join("")
-      .toUpperCase() ?? "··";
-
-  const StatusIcon = status.icon;
-
-  return (
-    <div className="flex items-center gap-3 rounded-xl border border-border bg-card px-3.5 py-2.5 shadow-[0px_2px_5px_rgba(112,144,176,0.12)] dark:shadow-[0px_2px_5px_rgba(0,0,0,0.3)]">
-      <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-brand-sky/15 text-[12px] font-extrabold text-brand-sky-text">
-        {initials}
-      </div>
-      <div className="min-w-0 flex-1">
-        <div className="truncate text-sm font-bold text-foreground">{member.name}</div>
-      </div>
-      <span
-        className={cn(
-          "inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11.5px] font-bold",
-          status.className,
-        )}
-      >
-        <StatusIcon className="size-3.5" />
-        {status.label}
-      </span>
-      {member.attended && (
-        <DropdownMenu>
-          <DropdownMenuTrigger
-            render={<Button variant="ghost" size="icon-sm" />}
-            title="Member actions"
-            aria-label="Member actions"
-          >
-            <MoreHorizontal />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-auto">
-            <DropdownMenuItem disabled={disabled} onClick={handleUndo}>
-              <RotateCcw />
-              Undo check-in
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      )}
-    </div>
-  );
-}
 
 function DashboardEvents() {
   const queryClient = useQueryClient();
@@ -241,8 +98,6 @@ function DashboardEvents() {
   const [detail, setDetail] = useState<DashboardEvent>();
   const [checkin, setCheckin] = useState<DashboardEvent>();
   const [roster, setRoster] = useState<DashboardEvent>();
-  const [rosterTab, setRosterTab] = useState<"qr" | "roster">("qr");
-  const [copied, setCopied] = useState(false);
 
   const { data: events } = useQuery(eventsListQueryOptions);
   const { data: me } = useQuery(meQueryOptions);
@@ -251,14 +106,6 @@ function DashboardEvents() {
   const creatorQuery = useQuery({
     ...memberQueryOptions(detail?.creator_id ?? ""),
     enabled: !!detail?.creator_id,
-  });
-  const codeQuery = useQuery({
-    ...eventAttendanceCodeQueryOptions(roster?.id ?? ""),
-    enabled: !!roster && rosterTab === "qr",
-  });
-  const rosterQuery = useQuery({
-    ...eventAttendanceQueryOptions(roster?.id ?? ""),
-    enabled: !!roster && rosterTab === "roster",
   });
 
   const { mutate: joinMutate } = useMutation({
@@ -270,17 +117,6 @@ function DashboardEvents() {
       return queryClient.invalidateQueries({ queryKey: plannedEventsQueryOptions.queryKey });
     },
     onError: () => toast.error("Couldn't RSVP. Please try again."),
-  });
-  const { mutate: removeMutate, isPending: isRemoving } = useMutation({
-    mutationFn: async (memberId: string) => {
-      await axios.delete(`${API_BASE_URL}/events/${roster?.id ?? ""}/attendance/${memberId}`);
-    },
-    onSuccess: () => {
-      toast.success("Check-in undone.");
-      return queryClient.invalidateQueries({
-        queryKey: eventAttendanceQueryOptions(roster?.id ?? "").queryKey,
-      });
-    },
   });
 
   const handleRsvp = useCallback(
@@ -307,8 +143,6 @@ function DashboardEvents() {
   }, []);
   const openRosterFromDetail = useCallback((event: DashboardEvent) => {
     setDetail(undefined);
-    setRosterTab("qr");
-    setCopied(false);
     setRoster(event);
   }, []);
   const closeDetail = useCallback((open: boolean) => {
@@ -320,21 +154,6 @@ function DashboardEvents() {
   const closeRoster = useCallback((open: boolean) => {
     if (!open) setRoster(undefined);
   }, []);
-
-  const code = (codeQuery.data?.code ?? "").slice(0, 8);
-  const copyCode = useCallback(() => {
-    navigator.clipboard
-      .writeText(code)
-      .then(() => {
-        setCopied(true);
-        setTimeout(() => {
-          setCopied(false);
-        }, 1800);
-      })
-      .catch(() => {
-        toast.error("Couldn't copy the code.");
-      });
-  }, [code]);
 
   const dashboardEvents = useMemo<DashboardEvent[]>(
     () =>
@@ -381,11 +200,6 @@ function DashboardEvents() {
     !!detail &&
     !!me &&
     (me.roles.includes("admin") || me.roles.includes("leads") || detail.creator_id === me.id);
-
-  const rosterMembers = rosterQuery.data?.data ?? [];
-  const plannedCount = rosterMembers.filter((member) => member.planned).length;
-  const attendedCount = rosterMembers.filter((member) => member.attended).length;
-  const checkIn = roster ? determineCheckIn(roster, now) : "ended";
 
   return (
     <div className="flex flex-col gap-5">
@@ -508,80 +322,7 @@ function DashboardEvents() {
         />
       )}
 
-      {roster && (
-        <Dialog open onOpenChange={closeRoster}>
-          <DialogContent className="max-h-[88svh] gap-4 overflow-y-auto sm:max-w-135">
-            <DialogHeader>
-              <DialogTitle className="text-lg font-extrabold">Attendance</DialogTitle>
-              <DialogDescription>{roster.name}</DialogDescription>
-            </DialogHeader>
-
-            <Tabs value={rosterTab} onValueChange={setRosterTab} className="gap-4">
-              <TabsList className="h-10 w-full border border-border">
-                <TabsTrigger value="qr" className="font-bold data-active:border-border">
-                  Check-in QR
-                </TabsTrigger>
-                <TabsTrigger value="roster" className="font-bold data-active:border-border">
-                  Roster · {String(rosterMembers.length)}
-                </TabsTrigger>
-              </TabsList>
-
-              <TabsContent value="qr" className="flex flex-col items-center gap-4.5">
-                <CheckInPanel
-                  code={code}
-                  copied={copied}
-                  onCopy={copyCode}
-                  state={checkIn}
-                  closesAt={fmtClock(roster.end_at, roster.timezone)}
-                />
-              </TabsContent>
-
-              <TabsContent value="roster" className="flex flex-col gap-3">
-                <div className="flex gap-3">
-                  <div className="flex-1 rounded-xl border border-border bg-card px-3.5 py-3 shadow-[0px_2px_5px_rgba(112,144,176,0.12)] dark:shadow-[0px_2px_5px_rgba(0,0,0,0.3)]">
-                    <div className="text-2xl leading-none font-extrabold text-brand-sky">
-                      {String(plannedCount)}
-                    </div>
-                    <div className="mt-1 text-xs font-semibold text-muted-foreground">
-                      Planned (RSVP'd)
-                    </div>
-                  </div>
-                  <div className="flex-1 rounded-xl border border-border bg-card px-3.5 py-3 shadow-[0px_2px_5px_rgba(112,144,176,0.12)] dark:shadow-[0px_2px_5px_rgba(0,0,0,0.3)]">
-                    <div className="text-2xl leading-none font-extrabold text-[#15a66e] dark:text-[#3fd68c]">
-                      {String(attendedCount)}
-                    </div>
-                    <div className="mt-1 text-xs font-semibold text-muted-foreground">Attended</div>
-                  </div>
-                </div>
-                <div className="-mx-2 flex max-h-72 flex-col gap-2 overflow-y-auto p-2">
-                  {rosterQuery.isPending && (
-                    <p className="px-2 py-6 text-center text-sm text-muted-foreground">
-                      Loading roster…
-                    </p>
-                  )}
-                  {!rosterQuery.isPending && rosterMembers.length === 0 && (
-                    <p className="px-2 py-6 text-center text-sm text-muted-foreground">
-                      No attendees yet.
-                    </p>
-                  )}
-                  {rosterMembers.map((member) => (
-                    <RosterRow
-                      key={member.id}
-                      member={member}
-                      disabled={isRemoving}
-                      onUndo={removeMutate}
-                    />
-                  ))}
-                </div>
-                <p className="text-[11.5px]/relaxed text-muted-foreground">
-                  Undo clears a member's attended flag but keeps their RSVP — for correcting a
-                  mistaken check-in.
-                </p>
-              </TabsContent>
-            </Tabs>
-          </DialogContent>
-        </Dialog>
-      )}
+      {roster && <AttendanceDialog event={roster} now={now} open onOpenChange={closeRoster} />}
     </div>
   );
 }

--- a/src/routes/dashboard/index.tsx
+++ b/src/routes/dashboard/index.tsx
@@ -1,7 +1,7 @@
 import { type ClientMember, ROLE_META, ROLES_BY_RANK } from "./route";
 
 import { queryOptions, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
 import axios from "axios";
 import {
   ArrowRight,
@@ -17,8 +17,9 @@ import {
 import { useCallback, useMemo, useState } from "react";
 import { toast } from "sonner";
 
+import { AttendanceDialog } from "@/components/app/attendance-dialog";
 import { CheckInDialog } from "@/components/app/check-in-dialog";
-import { EventCard, StatTile } from "@/components/app/dashboard-events";
+import { EventCard, EventDetailDialog, StatTile } from "@/components/app/dashboard-events";
 import { Button } from "@/components/ui/button";
 import {
   Carousel,
@@ -118,6 +119,17 @@ export const meQueryOptions = queryOptions({
 export const plannedEventsQueryOptions = memberEventsQueryOptions("planned");
 export const attendedEventsQueryOptions = memberEventsQueryOptions("attended");
 
+const memberQueryOptions = (memberId: string) =>
+  queryOptions({
+    queryKey: ["members", memberId],
+    queryFn: async () => {
+      const { data } = await axios.get<{ id: string; name: string }>(
+        `${API_BASE_URL}/members/${memberId}`,
+      );
+      return data;
+    },
+  });
+
 /// Helper functions
 
 function heroEyebrowText(live: boolean, planned: boolean) {
@@ -129,16 +141,21 @@ function heroEyebrowText(live: boolean, planned: boolean) {
 /// Route
 
 function DashboardHome() {
-  const navigate = useNavigate();
   const queryClient = useQueryClient();
+
+  const [now] = useState(() => new Date());
+  const [detail, setDetail] = useState<DashboardEvent>();
+  const [checkinEvent, setCheckinEvent] = useState<DashboardEvent>();
+  const [roster, setRoster] = useState<DashboardEvent>();
 
   const { data: events, isPending } = useQuery(eventsListQueryOptions);
   const { data: me } = useQuery(meQueryOptions);
   const { data: plannedEvents } = useQuery(plannedEventsQueryOptions);
   const { data: attendedEvents } = useQuery(attendedEventsQueryOptions);
-
-  const [now] = useState(() => new Date());
-  const [checkinEvent, setCheckinEvent] = useState<DashboardEvent>();
+  const creatorQuery = useQuery({
+    ...memberQueryOptions(detail?.creator_id ?? ""),
+    enabled: !!detail?.creator_id,
+  });
 
   const { mutate: joinMutate } = useMutation({
     mutationFn: async (eventId: string) => {
@@ -164,16 +181,28 @@ function DashboardHome() {
     },
     [joinMutate, queryClient],
   );
-  const goToEvents = useCallback(() => {
-    navigate({ to: "/dashboard/events" }).catch(() => {});
-  }, [navigate]);
-  const closeCheckin = useCallback((open: boolean) => {
-    if (!open) setCheckinEvent(undefined);
-  }, []);
   const invalidateAttended = useCallback(
     () => queryClient.invalidateQueries({ queryKey: attendedEventsQueryOptions.queryKey }),
     [queryClient],
   );
+
+  const openCheckinFromDetail = useCallback((event: DashboardEvent) => {
+    setDetail(undefined);
+    setCheckinEvent(event);
+  }, []);
+  const openRosterFromDetail = useCallback((event: DashboardEvent) => {
+    setDetail(undefined);
+    setRoster(event);
+  }, []);
+  const closeDetail = useCallback((open: boolean) => {
+    if (!open) setDetail(undefined);
+  }, []);
+  const closeCheckin = useCallback((open: boolean) => {
+    if (!open) setCheckinEvent(undefined);
+  }, []);
+  const closeRoster = useCallback((open: boolean) => {
+    if (!open) setRoster(undefined);
+  }, []);
 
   const { hero, heroDate, heroLive, heroEyebrow, myUpcoming, myRsvpsSub, rail, attendedCount } =
     useMemo(() => {
@@ -218,6 +247,12 @@ function DashboardHome() {
   }, [hero, handleRsvp]);
 
   const role = ROLES_BY_RANK.find((item) => me?.roles.includes(item));
+
+  const organizerName = detail?.creator_id ? creatorQuery.data?.name : undefined;
+  const canManageDetail =
+    !!detail &&
+    !!me &&
+    (me.roles.includes("admin") || me.roles.includes("leads") || detail.creator_id === me.id);
 
   return isPending ? (
     <div className="flex flex-col gap-5.5">
@@ -372,7 +407,7 @@ function DashboardHome() {
                 <EventCard
                   event={event}
                   now={now}
-                  onOpen={goToEvents}
+                  onOpen={setDetail}
                   onRsvp={handleRsvp}
                   onCheckin={setCheckinEvent}
                 />
@@ -429,7 +464,7 @@ function DashboardHome() {
                 <EventCard
                   event={event}
                   now={now}
-                  onOpen={goToEvents}
+                  onOpen={setDetail}
                   onRsvp={handleRsvp}
                   onCheckin={setCheckinEvent}
                 />
@@ -454,6 +489,20 @@ function DashboardHome() {
         </div>
       </Carousel>
 
+      {detail && (
+        <EventDetailDialog
+          event={detail}
+          now={now}
+          open
+          onOpenChange={closeDetail}
+          canManage={canManageDetail}
+          organizerName={organizerName}
+          onRsvp={handleRsvp}
+          onCheckin={openCheckinFromDetail}
+          onManageAttendance={openRosterFromDetail}
+        />
+      )}
+
       {checkinEvent && (
         <CheckInDialog
           event={checkinEvent}
@@ -463,6 +512,8 @@ function DashboardHome() {
           onVerified={invalidateAttended}
         />
       )}
+
+      {roster && <AttendanceDialog event={roster} now={now} open onOpenChange={closeRoster} />}
     </div>
   );
 }

--- a/src/routes/dashboard/manage/events.tsx
+++ b/src/routes/dashboard/manage/events.tsx
@@ -34,7 +34,7 @@ import { toast } from "sonner";
 import { Temporal } from "temporal-polyfill";
 import { z } from "zod";
 
-import { CheckInPanel } from "@/components/app/check-in-panel";
+import { AttendanceDialog } from "@/components/app/attendance-dialog";
 import { EmptyState } from "@/components/app/dashboard-events";
 import { DataPagination } from "@/components/app/data-pagination";
 import { ThumbnailDropzone } from "@/components/app/thumbnail-dropzone";
@@ -67,7 +67,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import {
   type EventType,
@@ -77,12 +76,10 @@ import {
   EVENT_TYPE_CLASSES,
   EVENT_TYPE_META,
   EVENT_TYPES,
-  determineCheckIn,
   fmtClock,
   fmtDay,
 } from "@/lib/dashboard-events";
 import { cn } from "@/lib/utils";
-import { RosterRow } from "@/routes/dashboard/events";
 import { meQueryOptions } from "@/routes/dashboard/index";
 
 export const Route = createFileRoute("/dashboard/manage/events")({
@@ -102,7 +99,6 @@ export const Route = createFileRoute("/dashboard/manage/events")({
 
 type ThumbnailUpload = { url: string } | { hash: string; url: string };
 type RowHandler = (event: MouseEvent<HTMLElement>) => void;
-type RosterTab = "qr" | "roster";
 
 interface AttendanceSummary {
   planned: number;
@@ -133,11 +129,6 @@ interface SaveVars {
   event: FullEvent;
   thumbnailFile?: File;
   removeThumbnail?: boolean;
-}
-
-interface UndoVars {
-  eventId: string;
-  memberId: string;
 }
 
 declare module "@tanstack/react-table" {
@@ -310,8 +301,6 @@ const TAG_PILL_CLASS =
 const TIME_INPUT_CLASS =
   "border-border bg-background appearance-none [&::-webkit-calendar-picker-indicator]:hidden [&::-webkit-calendar-picker-indicator]:appearance-none";
 const FIELD_ERROR_CLASS = "text-[12px] font-semibold text-[#e13737] dark:text-[#ff6b6b]";
-const ROSTER_STAT_CLASS =
-  "flex-1 rounded-xl border border-border bg-card px-3.5 py-3 shadow-[0px_2px_5px_rgba(112,144,176,0.12)] dark:shadow-[0px_2px_5px_rgba(0,0,0,0.3)]";
 const FACT_TILE_CLASS = "rounded-xl border border-border bg-muted/60 px-3.5 py-3";
 const FACT_LABEL_CLASS =
   "mb-1 text-[10.5px] font-bold tracking-[0.06em] text-muted-foreground uppercase";
@@ -378,17 +367,6 @@ const eventAttendanceQueryOptions = (eventId: string) =>
     },
   });
 
-const eventAttendanceCodeQueryOptions = (eventId: string) =>
-  queryOptions({
-    queryKey: ["events", eventId, "attendance-code"],
-    queryFn: async () => {
-      const { data } = await axios.get<{ code: string }>(
-        `${API_BASE_URL}/events/${eventId}/attendance-code`,
-      );
-      return data;
-    },
-  });
-
 /// Helper functions
 
 const summaryCache = new WeakMap<readonly AttendanceMember[], AttendanceSummary>();
@@ -439,21 +417,10 @@ function ManageEventsPage() {
   const [detailId, setDetailId] = useState<string>();
   const [confirmId, setConfirmId] = useState<string>();
   const [rosterId, setRosterId] = useState<string>();
-  const [rosterTab, setRosterTab] = useState<RosterTab>("qr");
-  const [copied, setCopied] = useState(false);
 
   const { data: events, isPending } = useQuery(manageEventsQueryOptions);
   const { data: me } = useQuery(meQueryOptions);
   const meId = me?.id;
-
-  const codeQuery = useQuery({
-    ...eventAttendanceCodeQueryOptions(rosterId ?? ""),
-    enabled: !!rosterId && rosterTab === "qr",
-  });
-  const rosterQuery = useQuery({
-    ...eventAttendanceQueryOptions(rosterId ?? ""),
-    enabled: !!rosterId && rosterTab === "roster",
-  });
 
   const invalidateManage = useCallback(
     () => queryClient.invalidateQueries({ queryKey: MANAGE_EVENTS_KEY }),
@@ -516,16 +483,6 @@ function ManageEventsPage() {
     onError: () => toast.error("Couldn't delete the event. Please try again."),
     onSuccess: () => toast.success("Event deleted."),
     onSettled: invalidateManage,
-  });
-
-  const { mutate: undoCheckin, isPending: isUndoing } = useMutation({
-    mutationFn: async ({ eventId, memberId }: UndoVars) => {
-      await axios.delete(`${API_BASE_URL}/events/${eventId}/attendance/${memberId}`);
-    },
-    onError: () => toast.error("Couldn't undo the check-in. Please try again."),
-    onSuccess: () => toast.success("Check-in undone."),
-    onSettled: (_data, _error, { eventId }) =>
-      queryClient.invalidateQueries({ queryKey: eventAttendanceQueryOptions(eventId).queryKey }),
   });
 
   const form = useForm({
@@ -650,22 +607,11 @@ function ManageEventsPage() {
   /// Roster actions
 
   const openRoster = useCallback((event: MouseEvent<HTMLElement>) => {
-    setRosterTab("qr");
-    setCopied(false);
     setRosterId(event.currentTarget.dataset.id);
   }, []);
   const closeRoster = useCallback((open: boolean) => {
     if (!open) setRosterId(undefined);
   }, []);
-  const changeRosterTab = useCallback((value: string) => {
-    setRosterTab(value as RosterTab);
-  }, []);
-  const handleRosterUndo = useCallback(
-    (memberId: string) => {
-      if (rosterId) undoCheckin({ eventId: rosterId, memberId });
-    },
-    [rosterId, undoCheckin],
-  );
 
   /// Search actions
 
@@ -723,21 +669,6 @@ function ManageEventsPage() {
     [form],
   );
 
-  const code = (codeQuery.data?.code ?? "").slice(0, 8);
-  const copyCode = useCallback(() => {
-    navigator.clipboard
-      .writeText(code)
-      .then(() => {
-        setCopied(true);
-        setTimeout(() => {
-          setCopied(false);
-        }, 1800);
-      })
-      .catch(() => {
-        toast.error("Couldn't copy the code.");
-      });
-  }, [code]);
-
   const manageable = useMemo(() => {
     const hasRole = me?.roles.some((role) => EVENT_MANAGE_ROLES.has(role)) ?? false;
     return (events ?? EMPTY_EVENTS).filter((event) => hasRole || event.creator_id === me?.id);
@@ -791,14 +722,9 @@ function ManageEventsPage() {
     [now, meId, attendance, openDetail, openRoster, openEditor, askDelete],
   );
 
-  const rosterMembers = rosterQuery.data?.data ?? [];
-  const { planned: plannedCount, attended: attendedCount } = summarizeAttendance(rosterMembers);
-
   const rosterEvent = (events ?? EMPTY_EVENTS).find((event) => event.id === rosterId);
   const confirmName = (events ?? EMPTY_EVENTS).find((event) => event.id === confirmId)?.name;
   const detailEvent = (events ?? EMPTY_EVENTS).find((event) => event.id === detailId);
-
-  const windowState = rosterEvent ? determineCheckIn(rosterEvent, now) : "ended";
 
   return (
     <div className="flex flex-col gap-5">
@@ -1185,80 +1111,9 @@ function ManageEventsPage() {
         )}
       </Dialog>
 
-      <Dialog open={rosterId !== undefined} onOpenChange={closeRoster}>
-        {rosterEvent && (
-          <DialogContent className="max-h-[88svh] gap-4 overflow-y-auto sm:max-w-135">
-            <DialogHeader>
-              <DialogTitle className="text-lg font-extrabold">Attendance</DialogTitle>
-              <DialogDescription>{rosterEvent.name}</DialogDescription>
-            </DialogHeader>
-
-            <Tabs value={rosterTab} onValueChange={changeRosterTab} className="gap-4">
-              <TabsList className="h-10 w-full border border-border">
-                <TabsTrigger value="qr" className="font-bold data-active:border-border">
-                  Check-in QR
-                </TabsTrigger>
-                <TabsTrigger value="roster" className="font-bold data-active:border-border">
-                  Roster · {rosterMembers.length}
-                </TabsTrigger>
-              </TabsList>
-
-              <TabsContent value="qr" className="flex flex-col items-center gap-4.5">
-                <CheckInPanel
-                  code={code}
-                  copied={copied}
-                  onCopy={copyCode}
-                  state={windowState}
-                  closesAt={fmtClock(rosterEvent.end_at, rosterEvent.timezone)}
-                />
-              </TabsContent>
-
-              <TabsContent value="roster" className="flex flex-col gap-3">
-                <div className="flex gap-3">
-                  <div className={ROSTER_STAT_CLASS}>
-                    <div className="text-2xl leading-none font-extrabold text-brand-sky">
-                      {plannedCount}
-                    </div>
-                    <div className="mt-1 text-xs font-semibold text-muted-foreground">
-                      Planned (RSVP'd)
-                    </div>
-                  </div>
-                  <div className={ROSTER_STAT_CLASS}>
-                    <div className="text-2xl leading-none font-extrabold text-[#15a66e] dark:text-[#3fd68c]">
-                      {attendedCount}
-                    </div>
-                    <div className="mt-1 text-xs font-semibold text-muted-foreground">Attended</div>
-                  </div>
-                </div>
-                <div className="-mx-2 flex max-h-72 flex-col gap-2 overflow-y-auto p-2">
-                  {rosterQuery.isPending && (
-                    <p className="px-2 py-6 text-center text-sm text-muted-foreground">
-                      Loading roster…
-                    </p>
-                  )}
-                  {!rosterQuery.isPending && rosterMembers.length === 0 && (
-                    <p className="px-2 py-6 text-center text-sm text-muted-foreground">
-                      No attendees yet.
-                    </p>
-                  )}
-                  {rosterMembers.map((member) => (
-                    <RosterRow
-                      key={member.id}
-                      member={member}
-                      disabled={isUndoing}
-                      onUndo={handleRosterUndo}
-                    />
-                  ))}
-                </div>
-                <p className="text-[11.5px]/relaxed text-muted-foreground">
-                  Undo clears a member's attended flag but keeps their RSVP — for correcting a
-                  mistaken check-in.
-                </p>
-              </TabsContent>
-            </Tabs>
-          </DialogContent>
-        )}
-      </Dialog>
+      {rosterEvent && (
+        <AttendanceDialog event={rosterEvent} now={now} open onOpenChange={closeRoster} />
+      )}
     </div>
   );
 }

--- a/src/routes/event/$eventId.tsx
+++ b/src/routes/event/$eventId.tsx
@@ -1,0 +1,341 @@
+import { queryOptions, skipToken, useMutation, useQuery } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import axios from "axios";
+import { ChevronLeft, Clock, MapPin, Ticket } from "lucide-react";
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  type EventType,
+  type FullEvent,
+  EVENT_TYPE_CLASSES,
+  EVENT_TYPE_META,
+  fmtClock,
+  fmtDay,
+  isPastEvent,
+  monthDay,
+} from "@/lib/dashboard-events";
+import { cn } from "@/lib/utils";
+
+export const Route = createFileRoute("/event/$eventId")({
+  component: Event,
+  loader: ({ context: { queryClient }, params: { eventId } }) =>
+    queryClient.prefetchQuery(eventDetailQueryOptions(eventId)),
+});
+
+/// Types and Interfaces
+
+interface EventOrganizer {
+  id: string;
+  name: string;
+}
+
+/// Constants with data
+
+const EVENT_TYPE_ACCENTS: Record<EventType, string> = {
+  general: "[--type-color:#2e7d9a] dark:[--type-color:#5b9bd5]",
+  sig_swe: "[--type-color:#3da9fc] dark:[--type-color:#6cbcff]",
+  sig_ai: "[--type-color:#00c9a7] dark:[--type-color:#2fdcbb]",
+  sig_cyber: "[--type-color:#ff6b6b] dark:[--type-color:#ff9a9a]",
+  sig_data: "[--type-color:#f7b731] dark:[--type-color:#ffd56b]",
+  sig_arch: "[--type-color:#fc5c7d] dark:[--type-color:#ff8fa6]",
+  sig_graph: "[--type-color:#a55eea] dark:[--type-color:#c79bf2]",
+  social: "[--type-color:#fd9644] dark:[--type-color:#ffb37a]",
+  misc: "[--type-color:#93a3b6] dark:[--type-color:#b4c2d2]",
+};
+
+const JOIN_ERRORS: Record<number, string | undefined> = {
+  401: "Sign in to join this event.",
+  403: "This event has already ended.",
+  404: "This event no longer exists.",
+  409: "You've already joined this event.",
+};
+
+const EVENT_STATUSES = {
+  past: { label: "Past", className: "border-border bg-muted text-muted-foreground" },
+  live: { label: "Happening now", className: "border-sig-ai/30 bg-sig-ai/15 text-sig-ai" },
+  upcoming: { label: "Upcoming", className: "border-sig-swe/30 bg-sig-swe/15 text-sig-swe" },
+};
+
+/// Module-scoped constants
+
+const API_BASE_URL =
+  (import.meta.env.VITE_API_URL as string | undefined) ?? "http://localhost:8000";
+
+const LONG_DATE_OPTIONS: Intl.DateTimeFormatOptions = {
+  weekday: "long",
+  month: "long",
+  day: "numeric",
+  year: "numeric",
+};
+
+const PAGE_CLASSES = "mx-auto max-w-225 px-4 md:px-12";
+const BADGE_CLASSES = cn(
+  "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.75",
+  "text-[11px] font-bold tracking-wide uppercase",
+);
+const DETAIL_PANEL_CLASSES = cn(
+  "rounded-[20px] border border-border bg-card p-5",
+  "shadow-[0px_4px_14px_rgba(112,144,176,0.14)] dark:shadow-[0px_4px_14px_rgba(0,0,0,0.4)]",
+);
+const DETAIL_LABEL_CLASSES =
+  "text-[11px] font-semibold tracking-[0.06em] text-muted-foreground uppercase";
+const DETAIL_VALUE_CLASSES = "mt-1 flex items-start gap-1.75 text-sm font-bold text-foreground";
+const SECTION_LABEL_CLASSES =
+  "mb-2.5 text-[11px] font-bold tracking-[0.08em] text-muted-foreground uppercase";
+
+/// Tanstack Query options
+
+const eventDetailQueryOptions = (eventId: string) =>
+  queryOptions({
+    queryKey: ["events", eventId, "detail"],
+    queryFn: async () => {
+      const { data } = await axios.get<FullEvent>(`${API_BASE_URL}/events/${eventId}`);
+      return data;
+    },
+  });
+
+const eventOrganizerQueryOptions = (memberId: string | null | undefined) =>
+  queryOptions({
+    queryKey: ["members", memberId],
+    queryFn: memberId
+      ? async () => {
+          const { data } = await axios.get<EventOrganizer>(`${API_BASE_URL}/members/${memberId}`);
+          return data;
+        }
+      : skipToken,
+    staleTime: 300_000,
+  });
+
+/// Helper functions
+
+function eventStatus(event: FullEvent, now: Date) {
+  if (isPastEvent(event, now)) return EVENT_STATUSES.past;
+  if (Date.parse(event.start_at) <= now.getTime()) return EVENT_STATUSES.live;
+  return EVENT_STATUSES.upcoming;
+}
+
+/// Route Component
+
+function Event() {
+  const { eventId } = Route.useParams();
+
+  const { data: event, isPending, isError } = useQuery(eventDetailQueryOptions(eventId));
+  const { data: organizer } = useQuery(eventOrganizerQueryOptions(event?.creator_id));
+
+  const [now] = useState(() => new Date());
+
+  const { mutate: joinEvent, isPending: isJoining } = useMutation({
+    mutationFn: async () => {
+      const { data } = await axios.post<{ message: string }>(
+        `${API_BASE_URL}/events/${eventId}/join`,
+      );
+      return data;
+    },
+    onSuccess: () => {
+      toast.success("You're on the list! We'll see you there.");
+    },
+    onError: (error) => {
+      const status = axios.isAxiosError(error) ? error.response?.status : undefined;
+      toast.error(JOIN_ERRORS[status ?? 0] ?? "Could not join this event. Please try again.");
+    },
+  });
+
+  const handleJoin = useCallback(() => {
+    joinEvent();
+  }, [joinEvent]);
+
+  const organizerName = organizer?.name ?? (event?.creator_id ? "…" : "Unknown organizer");
+  const status = event ? eventStatus(event, now) : undefined;
+  const startDate = event ? monthDay(event.start_at, event.timezone) : undefined;
+
+  return (
+    <div className="bg-background">
+      <div className={cn(PAGE_CLASSES, "pt-6 md:pt-10")}>
+        <Link
+          to="/events"
+          className={cn(
+            "inline-flex items-center gap-1.5 text-[13px] font-semibold",
+            "text-brand-text-sub transition-colors hover:text-foreground",
+          )}
+        >
+          <ChevronLeft className="size-4" />
+          Back to Events
+        </Link>
+      </div>
+
+      {isPending && (
+        <div className={cn(PAGE_CLASSES, "flex flex-col gap-5 py-8 md:py-12")}>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex flex-wrap gap-2.5">
+              <Skeleton className="h-5 w-16 rounded-full" />
+              <Skeleton className="h-5 w-24 rounded-full" />
+            </div>
+            <Skeleton className="h-8 w-28 rounded-full" />
+          </div>
+          <Skeleton className="mt-2 h-9 w-2/3 rounded-md" />
+          <Skeleton className="h-1 w-12 rounded-full" />
+          <Skeleton className="h-45 rounded-[20px]" />
+          <div className="mt-2 flex flex-col gap-2">
+            <Skeleton className="h-4 w-full rounded-sm" />
+            <Skeleton className="h-4 w-11/12 rounded-sm" />
+            <Skeleton className="h-4 w-3/4 rounded-sm" />
+          </div>
+        </div>
+      )}
+
+      {isError && (
+        <div className={cn(PAGE_CLASSES, "py-16 text-center text-base text-muted-foreground")}>
+          Event not found.
+        </div>
+      )}
+
+      {event && status && (
+        <article
+          className={cn(
+            PAGE_CLASSES,
+            "py-8 md:py-12",
+            "[contain-intrinsic-size:auto_900px] [content-visibility:auto]",
+            EVENT_TYPE_ACCENTS[event.type],
+          )}
+        >
+          <header className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:gap-2.5">
+            <div className="flex flex-wrap items-center gap-2.5">
+              <span className={cn(BADGE_CLASSES, EVENT_TYPE_CLASSES[event.type].label)}>
+                {EVENT_TYPE_META[event.type].label}
+              </span>
+              <span className={cn(BADGE_CLASSES, status.className)}>
+                <span className="size-1.5 rounded-full bg-current" aria-hidden="true" />
+                {status.label}
+              </span>
+            </div>
+            {status !== EVENT_STATUSES.past && (
+              <Button
+                onClick={handleJoin}
+                disabled={isJoining}
+                className="h-10 rounded-full font-bold sm:ml-auto sm:h-8"
+              >
+                <Ticket className="size-4" />
+                {isJoining ? "Joining…" : "Join Event"}
+              </Button>
+            )}
+          </header>
+
+          {event.thumbnail ? (
+            <img
+              src={event.thumbnail.url}
+              alt=""
+              fetchPriority="high"
+              decoding="async"
+              className={cn(
+                "mt-5 w-full rounded-2xl border border-border object-cover",
+                "h-45 bg-(--type-color)/15 md:h-70",
+              )}
+            />
+          ) : undefined}
+
+          <h1
+            className={cn(
+              "mt-5 leading-tight font-extrabold text-foreground",
+              "text-[30px] md:text-[44px]",
+            )}
+          >
+            {event.name}
+          </h1>
+
+          {event.tags && event.tags.length > 0 ? (
+            <ul aria-label="Tags" className="mt-3 flex flex-wrap gap-2">
+              {event.tags.map((tag) => (
+                <li
+                  key={tag}
+                  className={cn(
+                    "rounded-full border border-border bg-card",
+                    "px-3 py-1 text-xs font-semibold text-foreground",
+                  )}
+                >
+                  {tag}
+                </li>
+              ))}
+            </ul>
+          ) : undefined}
+
+          <div className="my-6 h-1 w-12 rounded-full bg-(--type-color)" />
+
+          <section>
+            <div className={SECTION_LABEL_CLASSES}>Details</div>
+            <div className={DETAIL_PANEL_CLASSES}>
+              <div className="flex items-center gap-4.5">
+                <div
+                  className={cn(
+                    "flex h-19 w-17 shrink-0 flex-col overflow-hidden text-center",
+                    "rounded-2xl border border-border",
+                  )}
+                >
+                  <div className="bg-(--type-color) py-1 text-[11px] font-extrabold tracking-[0.08em] text-white">
+                    {startDate?.mon}
+                  </div>
+                  <div className="flex flex-1 items-center justify-center text-[30px] leading-none font-extrabold text-foreground">
+                    {startDate?.day}
+                  </div>
+                </div>
+                <div className="min-w-0">
+                  <div className={DETAIL_LABEL_CLASSES}>When</div>
+                  <div className="mt-1 text-[15px] font-bold text-foreground md:text-base">
+                    {fmtDay(event.start_at, event.timezone, LONG_DATE_OPTIONS)}
+                  </div>
+                  <div className="mt-0.5 flex items-center gap-1.5 text-sm font-semibold text-brand-text-sub">
+                    <Clock className="size-3.5 shrink-0" />
+                    {fmtClock(event.start_at, event.timezone)} -{" "}
+                    {fmtClock(event.end_at, event.timezone)}
+                  </div>
+                </div>
+              </div>
+
+              <div className="mt-4.5 grid gap-4 border-t border-border pt-4.5 sm:grid-cols-2">
+                <div className="min-w-0">
+                  <div className={DETAIL_LABEL_CLASSES}>Where</div>
+                  <div className={DETAIL_VALUE_CLASSES}>
+                    <MapPin className="mt-0.5 size-4 shrink-0 text-(--type-color)" />
+                    {event.location}
+                  </div>
+                </div>
+                <div className="min-w-0">
+                  <div className={DETAIL_LABEL_CLASSES}>Hosted by</div>
+                  <div
+                    className={cn(
+                      DETAIL_VALUE_CLASSES,
+                      !event.creator_id && "font-semibold text-muted-foreground",
+                    )}
+                  >
+                    {organizer ? (
+                      <Avatar aria-hidden="true" className="size-5.5 text-[10px] after:hidden">
+                        <AvatarFallback className="bg-(--type-color)/20 text-[1em] font-bold text-(--type-color)">
+                          {organizer.name.charAt(0)}
+                        </AvatarFallback>
+                      </Avatar>
+                    ) : undefined}
+                    {organizerName}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section className="mt-8">
+            <div className={SECTION_LABEL_CLASSES}>Description</div>
+            <p className={cn("leading-[1.85] text-brand-text-sub", "text-[15px] md:text-[17px]")}>
+              {event.description}
+            </p>
+          </section>
+
+          <footer className="mt-8 border-t border-border pt-5 text-xs text-muted-foreground">
+            All times shown in {event.timezone}
+          </footer>
+        </article>
+      )}
+    </div>
+  );
+}

--- a/src/routes/events.tsx
+++ b/src/routes/events.tsx
@@ -387,8 +387,6 @@ function Events() {
                       {selectedEventType.label}
                     </span>
 
-                    {/* The title carries the way into the full page, so the footer keeps a
-                        single action instead of a second control competing with the CTA */}
                     <h3 className="text-sm/tight font-extrabold">
                       <Link
                         to="/event/$eventId"

--- a/src/routes/events.tsx
+++ b/src/routes/events.tsx
@@ -1,7 +1,7 @@
 import { Popover as PopoverPrimitive } from "@base-ui/react/popover";
 import type { CalendarType } from "@schedule-x/calendar";
 import { queryOptions, useMutation, useQuery } from "@tanstack/react-query";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
 import axios from "axios";
 import { MapPin } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
@@ -276,6 +276,8 @@ function Events() {
     [selectedEvent],
   );
 
+  const eventLinkParams = useMemo(() => ({ eventId: selectedEvent?.id ?? "" }), [selectedEvent]);
+
   const anchor = useMemo(
     () => (selected ? { getBoundingClientRect: () => selected.rect } : undefined),
     [selected],
@@ -385,8 +387,19 @@ function Events() {
                       {selectedEventType.label}
                     </span>
 
-                    <h3 className="text-sm/tight font-extrabold text-foreground">
-                      {selectedEvent.name}
+                    {/* The title carries the way into the full page, so the footer keeps a
+                        single action instead of a second control competing with the CTA */}
+                    <h3 className="text-sm/tight font-extrabold">
+                      <Link
+                        to="/event/$eventId"
+                        params={eventLinkParams}
+                        className={cn(
+                          "text-foreground underline-offset-2 transition-colors",
+                          "hover:text-brand-sky-text hover:underline",
+                        )}
+                      >
+                        {selectedEvent.name}
+                      </Link>
                     </h3>
 
                     <div className="flex flex-col gap-0.5 text-xs text-brand-text-sub">

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -2,10 +2,9 @@ import { SiDiscord, SiGithub, SiInstagram, type IconType } from "@icons-pack/rea
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import axios from "axios";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, Clock, MapPin } from "lucide-react";
 import { useMemo, type CSSProperties } from "react";
 
-import aboutUsImg from "@/assets/images/about-us.png";
 import beginningsLogo from "@/assets/images/beginnings-logo.png";
 import sigAiLogo from "@/assets/logos/sigs/ai.svg";
 import sigArchLogo from "@/assets/logos/sigs/arch.svg";
@@ -20,6 +19,14 @@ import {
   CarouselNext,
   CarouselPrevious,
 } from "@/components/ui/carousel";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  type EventThumbnailData,
+  EVENT_TYPE_CLASSES,
+  EVENT_TYPE_META,
+  fmtClock,
+  monthDay,
+} from "@/lib/dashboard-events";
 import { cn } from "@/lib/utils";
 
 export const Route = createFileRoute("/")({
@@ -50,6 +57,7 @@ interface ApiEvent {
   location: string;
   type: EventType;
   timezone: string;
+  thumbnail?: EventThumbnailData | null;
   creator_id: string;
 }
 
@@ -69,12 +77,9 @@ interface SocialLink {
 const API_BASE_URL =
   (import.meta.env.VITE_API_URL as string | undefined) ?? "http://localhost:8000";
 
-// These are too expensive to compute, so we do it here
-const SHORT_MONTH_FMT = new Intl.DateTimeFormat("en-US", { month: "short" });
-const TIME_RANGE_FMT = new Intl.DateTimeFormat("en-US", {
-  hour: "numeric",
-  minute: "2-digit",
-});
+const CAROUSEL_NAV_CLASS = "static size-9 translate-0";
+
+const PAGE_LOADED_AT = new Date().toISOString();
 
 // One transform class shared by every tile. Per-tile angle is supplied via the
 // --tile-angle CSS variable (set by `angleClass` below), and CSS cos()/sin() compute
@@ -167,10 +172,12 @@ const eventsKeys = {
 };
 
 const eventsQueryOptions = queryOptions({
-  queryKey: eventsKeys.list({}),
+  queryKey: eventsKeys.list({ after: PAGE_LOADED_AT }),
   queryFn: async () => {
-    const { data } = await axios.get<EventsPage>(`${API_BASE_URL}/events`);
-    return data;
+    const { data } = await axios.get<EventsPage>(`${API_BASE_URL}/events`, {
+      params: { after: PAGE_LOADED_AT },
+    });
+    return data.data.toReversed();
   },
   // Events don't change minute-to-minute; treat the cache as fresh for a minute so
   // navigating back/forward doesn't refetch immediately.
@@ -185,8 +192,7 @@ const eventsQueryOptions = queryOptions({
 });
 
 function Index() {
-  const { data: eventsPage, isLoading: loading } = useQuery(eventsQueryOptions);
-  const events: ApiEvent[] = eventsPage?.data ?? [];
+  const { data: events = [], isLoading: loading } = useQuery(eventsQueryOptions);
 
   const carouselOptions = useMemo(() => ({ align: "start" as const }), []);
 
@@ -365,36 +371,48 @@ function Index() {
       </section>
 
       <section className="mx-auto max-w-300 px-5 py-12 md:p-20">
-        <div className="mb-8 flex flex-wrap items-end justify-between gap-3">
-          <div>
-            <h2 className="mb-2 text-[26px] font-bold text-foreground md:text-[42px]">Events</h2>
-            <p className="text-[13px] text-brand-text-sub md:text-base">
-              ACM @ UCM hosts 50+ events for our diverse community of students.
-            </p>
+        <Carousel opts={carouselOptions}>
+          <div className="mb-8 flex flex-wrap items-end justify-between gap-3">
+            <div>
+              <h2 className="mb-2 text-[26px] font-bold text-foreground md:text-[42px]">Events</h2>
+              <p className="text-[13px] text-brand-text-sub md:text-base">
+                ACM @ UCM hosts 50+ events for our diverse community of students.
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <Link
+                to="/"
+                className={cn(
+                  "cursor-pointer rounded-full border-2 border-brand-sky text-brand-sky",
+                  "px-5 py-2.5 text-sm font-bold",
+                  "transition-colors hover:bg-brand-sky/10",
+                )}
+              >
+                See All Events →
+              </Link>
+              {events.length > 1 && (
+                <>
+                  <CarouselPrevious className={CAROUSEL_NAV_CLASS} />
+                  <CarouselNext className={CAROUSEL_NAV_CLASS} />
+                </>
+              )}
+            </div>
           </div>
-          <Link
-            to="/"
-            className={cn(
-              "cursor-pointer rounded-full border-2 border-brand-sky text-brand-sky",
-              "px-5 py-2.5 text-sm font-bold",
-              "transition-colors hover:bg-brand-sky/10",
-            )}
-          >
-            See All Events →
-          </Link>
-        </div>
-        <Carousel opts={carouselOptions} className="mx-12">
           <CarouselContent className="-ml-4 py-4">
             {loading &&
               Array.from({ length: 4 }, (_, i) => (
                 <CarouselItem key={i} className="pl-4 sm:basis-1/2 lg:basis-1/3 xl:basis-1/4">
-                  <div className="flex h-full flex-col overflow-hidden rounded-3xl border border-border">
-                    <div className="aspect-16/10 w-full animate-pulse bg-muted" />
+                  <div className="flex h-full min-h-93.5 flex-col overflow-hidden rounded-3xl border border-border">
+                    <Skeleton className="aspect-video w-full rounded-none" />
                     <div className="flex flex-1 flex-col gap-3 p-5">
-                      <div className="h-3 w-1/2 animate-pulse rounded-sm bg-muted" />
-                      <div className="h-4 w-3/4 animate-pulse rounded-sm bg-muted" />
-                      <div className="h-3 w-full animate-pulse rounded-sm bg-muted" />
-                      <div className="h-3 w-5/6 animate-pulse rounded-sm bg-muted" />
+                      <Skeleton className="h-3 w-1/2 rounded-sm" />
+                      <Skeleton className="h-4 w-3/4 rounded-sm" />
+                      <Skeleton className="h-3 w-full rounded-sm" />
+                      <Skeleton className="h-3 w-5/6 rounded-sm" />
+                      <div className="mt-auto flex items-center justify-between gap-2 border-t border-border pt-3.5">
+                        <Skeleton className="h-6 w-16 rounded-full" />
+                        <Skeleton className="h-8 w-28 rounded-full" />
+                      </div>
                     </div>
                   </div>
                 </CarouselItem>
@@ -407,60 +425,93 @@ function Index() {
               </CarouselItem>
             )}
             {events.map((event) => {
-              const start = new Date(event.start_at);
+              const { mon, day } = monthDay(event.start_at, event.timezone);
               return (
                 <CarouselItem
                   key={event.id}
                   className="pl-4 sm:basis-1/2 lg:basis-1/3 xl:basis-1/4"
                 >
-                  <div className="flex h-full flex-col overflow-hidden rounded-3xl border border-border">
-                    <div className="relative aspect-16/10 w-full overflow-hidden">
-                      <img
-                        src={aboutUsImg}
-                        alt=""
-                        className="size-full object-contain p-6"
-                        loading="lazy"
-                      />
-                      <div className="absolute top-3 left-3 flex flex-col items-center rounded-2xl bg-card/95 px-3 py-1.5 shadow-md backdrop-blur-sm">
-                        <span className="text-[11px] font-bold text-brand-teal-alt">
-                          {SHORT_MONTH_FMT.format(start).toUpperCase()}
-                        </span>
-                        <span className="text-lg leading-none font-extrabold text-foreground">
-                          {start.getDate()}
-                        </span>
-                      </div>
-                    </div>
-                    <div className="flex flex-1 flex-col p-5">
-                      <div className="mb-1 text-[11px] font-semibold tracking-wide text-brand-text-sub uppercase">
-                        {TIME_RANGE_FMT.formatRange(start, new Date(event.end_at))} · @{" "}
-                        {event.location}
-                      </div>
-                      <h3 className="mb-2 text-[17px] leading-snug font-bold text-foreground">
-                        {event.name}
-                      </h3>
-                      <p className="mb-4 flex-1 text-sm/relaxed text-brand-text-sub">
-                        {event.description}
-                      </p>
-                      <button
-                        type="button"
+                  <div className="flex h-full min-h-93.5 flex-col overflow-hidden rounded-3xl border border-border">
+                    <div className="relative aspect-video w-full overflow-hidden bg-muted">
+                      {event.thumbnail ? (
+                        <img
+                          src={event.thumbnail.url}
+                          alt=""
+                          className="size-full object-cover"
+                          loading="lazy"
+                          decoding="async"
+                        />
+                      ) : (
+                        <div
+                          className={cn(
+                            "flex size-full items-center justify-center",
+                            EVENT_TYPE_CLASSES[event.type].chip,
+                          )}
+                        >
+                          <span
+                            className={cn(
+                              "rounded-full border px-4 py-1.25",
+                              "text-[11.5px] font-extrabold tracking-[0.12em] uppercase",
+                              EVENT_TYPE_CLASSES[event.type].label,
+                            )}
+                          >
+                            {EVENT_TYPE_META[event.type].label}
+                          </span>
+                        </div>
+                      )}
+                      <div
                         className={cn(
-                          "cursor-pointer self-start rounded-full border-none bg-foreground text-background",
-                          "text-xs font-medium md:text-[13px]",
-                          "px-4 py-1.5 md:px-5 md:py-2",
-                          "shadow-[6px_6px_10px_rgba(0,29,53,0.25),-6px_-6px_10px_rgba(61,169,252,0.2)]",
-                          "transition-opacity hover:opacity-90",
+                          "absolute bottom-3 left-3 flex h-14 w-13 flex-col overflow-hidden text-center",
+                          "rounded-xl border border-border bg-card shadow-md",
                         )}
                       >
-                        Remind me
-                      </button>
+                        <div
+                          className={cn(
+                            "py-0.75 text-[10px] font-extrabold tracking-[0.08em] text-white",
+                            EVENT_TYPE_CLASSES[event.type].bar,
+                          )}
+                        >
+                          {mon}
+                        </div>
+                        <div className="flex flex-1 items-center justify-center text-[21px] font-extrabold text-foreground">
+                          {day}
+                        </div>
+                      </div>
+                    </div>
+                    <div className="flex flex-1 flex-col gap-2.5 p-5">
+                      <div>
+                        <span
+                          className={cn(
+                            "inline-block rounded-full px-2.5 py-1 text-[11.5px] font-bold",
+                            EVENT_TYPE_CLASSES[event.type].chip,
+                          )}
+                        >
+                          {EVENT_TYPE_META[event.type].label}
+                        </span>
+                        <h3 className="mt-2 text-[17px] leading-snug font-bold text-foreground">
+                          {event.name}
+                        </h3>
+                      </div>
+                      <p className="line-clamp-2 text-sm/relaxed text-brand-text-sub">
+                        {event.description}
+                      </p>
+                      <div className="mt-auto flex flex-col gap-1.5 border-t border-border pt-3.5">
+                        <span className="flex items-center gap-2 text-xs font-semibold text-muted-foreground">
+                          <Clock className="size-3.5 shrink-0" />
+                          {fmtClock(event.start_at, event.timezone)} -{" "}
+                          {fmtClock(event.end_at, event.timezone)}
+                        </span>
+                        <span className="flex items-center gap-2 text-xs font-semibold text-muted-foreground">
+                          <MapPin className="size-3.5 shrink-0" />
+                          {event.location}
+                        </span>
+                      </div>
                     </div>
                   </div>
                 </CarouselItem>
               );
             })}
           </CarouselContent>
-          <CarouselPrevious className="size-10" />
-          <CarouselNext className="size-10" />
         </Carousel>
       </section>
 


### PR DESCRIPTION
# Summary

This PR adds in:

- A new route (`event/$eventId.tsx`) that displays the more detailed information in a page of an event
- Whenever a event item is pressed on the dashboard, it originally redirected you to `dashboard/events.tsx`. Now it opens up a proper dialog instead.
    - Also deduped the code for it as well
- Events carousel in `index.tsx` also has been standardized to ensure that it looks the same as on the dashboard
    - Also the cards finally use the proper thumbnail url and default that we use across the codebase
    - Cards are updated to more closely match our current design

## Types of changes

What types of changes does your code introduce to the UC Merced's ACM Chapter Website?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
