### PR TITLE
Silence plugin timings from Rolldown

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -62,6 +62,9 @@ export default defineConfig({
   },
   build: {
     rolldownOptions: {
+      // Until Oxc has their Rust-port of the React Compiler stabilized, just
+      // silence the plugin timings for now
+      checks: { pluginTimings: false },
       output: {
         codeSplitting: {
           groups: [


### PR DESCRIPTION
# Summary

Currently, the plugin timings reported by Rolldown have to do with our React Compiler. We utilize the React Compiler pretty heavily to ensure site performance; at the cost of longer times at build time. This is the cost that has been accepted, and as we use the Babel version, this forces Rolldown to run it via JS (instead of running it natively on Rust). It has to go through the TS API --> NAPI Bindings --> Rust core (and back the other way), thus why it takes so long. Until Oxc pushes out a stable release of the React Compiler port to Rust that doesn't inflate binary sizes, we'll just have to wait for it. This is the best that we can do.

## Types of changes

What types of changes does your code introduce to the UC Merced's ACM Chapter Website?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [x] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
