### PR TITLE
Favor unified query methods for Tanstack Query v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@schedule-x/scroll-controller": "^4.6.1",
     "@schedule-x/theme-shadcn": "^4.6.1",
     "@tanstack/react-form": "^1.33.3",
-    "@tanstack/react-query": "^5.101.4",
+    "@tanstack/react-query": "^5.102.2",
     "@tanstack/react-router": "^1.170.23",
     "@tanstack/react-table": "^9.1.1",
     "axios": "^1.19.0",
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@hey-api/openapi-ts": "0.99.0",
     "@tailwindcss/vite": "^4.3.3",
-    "@tanstack/eslint-plugin-query": "^5.101.4",
+    "@tanstack/eslint-plugin-query": "^5.102.2",
     "@tanstack/eslint-plugin-router": "^1.162.0",
     "@tanstack/router-plugin": "^1.168.27",
     "@types/node": "^26.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^1.33.3
         version: 1.33.5(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/react-query':
-        specifier: ^5.101.4
-        version: 5.102.0(react@19.2.8)
+        specifier: ^5.102.2
+        version: 5.102.2(react@19.2.8)
       '@tanstack/react-router':
         specifier: ^1.170.23
         version: 1.170.32(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -115,8 +115,8 @@ importers:
         specifier: ^4.3.3
         version: 4.3.3(vite@8.2.2(@types/node@26.2.0)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
       '@tanstack/eslint-plugin-query':
-        specifier: ^5.101.4
-        version: 5.102.0(@typescript/typescript6@6.0.2)(eslint@10.9.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)
+        specifier: ^5.102.2
+        version: 5.102.2(@typescript/typescript6@6.0.2)(eslint@10.9.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)
       '@tanstack/eslint-plugin-router':
         specifier: ^1.162.0
         version: 1.162.0(@typescript/typescript6@6.0.2)(eslint@10.9.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)
@@ -2334,8 +2334,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@tanstack/eslint-plugin-query@5.102.0':
-    resolution: {integrity: sha512-x40F4QyjWjVaruFpkmX8yMZU4J/n17sA2hjpQhPbNu+G6UQA/Lu3+PLKxlVTukyrhV8UknSRVAWY4WjGjid3mg==}
+  '@tanstack/eslint-plugin-query@5.102.2':
+    resolution: {integrity: sha512-0uRcRXvrZN3JLtGDMXU8Qp/or/fp1VhDZEVcD8WrUc7CF0uWbJbloJ88dfFDhiocYP31wXX4Buar/WC31fS5Ug==}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: ^5.6.0 || ^6.0.0 || ^7.0.0
@@ -2359,8 +2359,8 @@ packages:
     resolution: {integrity: sha512-y/xtNPNt/YeyoVxE/JCx+T7yjEzpezmbb+toK8DDD1P4m7Kzs5YR956+7OKexG3f8aXgC3rLZl7b1V+yNUSy5w==}
     engines: {node: '>=18'}
 
-  '@tanstack/query-core@5.102.0':
-    resolution: {integrity: sha512-tvBzr11Q7StuMCEsIJdqX8TAWt6WZIzfw/yrSAjObZDerwTTPeCxeLXN2R8ZSn4ZxFpQV819Xn8QmoO+vtnDvw==}
+  '@tanstack/query-core@5.102.2':
+    resolution: {integrity: sha512-zQ5794PXBlV5Wl7N23SR1/Ss+wPE/h2Ye4XlKpm3omN8i8b/Fd4DAdqpLS2AXj5M/RMObt3k5qy3E7kzt/AvBA==}
 
   '@tanstack/react-form@1.33.5':
     resolution: {integrity: sha512-LlRB28qJwO/QCGaHvWnbdh4haBgTFiZVmzA2uzxSBS3YA7/IqrQ6HOBK70CkFQ+DbflZ7NawsmSln13h5iIdTA==}
@@ -2371,8 +2371,8 @@ packages:
       '@tanstack/react-start':
         optional: true
 
-  '@tanstack/react-query@5.102.0':
-    resolution: {integrity: sha512-0GyVyEcGt9M7jHPCua16hNVtstUXE2R4HsnNubFYcDs7DJaLzh1dSiXsADDU/cNn/SqrLfa0vRKyjUmbx4rZLA==}
+  '@tanstack/react-query@5.102.2':
+    resolution: {integrity: sha512-KxU8ZyOEuJ81eTSgXa8GQbk/jO/rz0elYtNKt3VMtM2pRjeO8ADIu7sqqmEjFKJKqco9h2N1ojIDuHs6VfDItQ==}
     peerDependencies:
       react: ^18 || ^19
 
@@ -4050,6 +4050,9 @@ packages:
 
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -6550,6 +6553,7 @@ snapshots:
   '@eslint/core@1.2.1':
     dependencies:
       '@types/json-schema': 7.0.15
+      json-schema: 0.4.0
 
   '@eslint/css-tree@4.0.5':
     dependencies:
@@ -7492,7 +7496,7 @@ snapshots:
 
   '@tanstack/devtools-event-client@0.4.4': {}
 
-  '@tanstack/eslint-plugin-query@5.102.0(@typescript/typescript6@6.0.2)(eslint@10.9.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)':
+  '@tanstack/eslint-plugin-query@5.102.2(@typescript/typescript6@6.0.2)(eslint@10.9.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
       '@typescript-eslint/utils': 8.67.0(@typescript/typescript6@6.0.2)(eslint@10.9.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)
       eslint: 10.9.0(jiti@2.7.0)(supports-color@7.2.0)
@@ -7519,7 +7523,7 @@ snapshots:
 
   '@tanstack/pacer-lite@0.1.1': {}
 
-  '@tanstack/query-core@5.102.0': {}
+  '@tanstack/query-core@5.102.2': {}
 
   '@tanstack/react-form@1.33.5(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
@@ -7529,9 +7533,9 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  '@tanstack/react-query@5.102.0(react@19.2.8)':
+  '@tanstack/react-query@5.102.2(react@19.2.8)':
     dependencies:
-      '@tanstack/query-core': 5.102.0
+      '@tanstack/query-core': 5.102.2
       react: 19.2.8
 
   '@tanstack/react-router@1.170.32(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
@@ -7687,6 +7691,7 @@ snapshots:
   '@types/react-dom@19.2.4(@types/react@19.2.18)':
     dependencies:
       '@types/react': 19.2.18
+      react: 19.2.8
 
   '@types/react@19.2.18':
     dependencies:
@@ -7758,7 +7763,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.67.0': {}
+  '@typescript-eslint/types@8.67.0':
+    dependencies:
+      typescript: 7.0.2
 
   '@typescript-eslint/typescript-estree@8.67.0(@typescript/typescript6@6.0.2)(supports-color@7.2.0)':
     dependencies:
@@ -8446,6 +8453,7 @@ snapshots:
       es-object-atoms: 1.1.2
       es-set-tostringtag: 2.1.0
       es-to-primitive: 1.3.4
+      for-each: 0.3.5
       function.prototype.name: 1.2.0
       get-intrinsic: 1.3.0
       get-proto: 1.0.1
@@ -9302,6 +9310,8 @@ snapshots:
   json-schema-typed@7.0.3: {}
 
   json-schema-typed@8.0.2: {}
+
+  json-schema@0.4.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,8 @@ trustLockfile: true
 allowBuilds:
   msgpackr-extract: false
   msw: false
+
+minimumReleaseAgeExclude:
+  - '@tanstack/eslint-plugin-query@5.102.2'
+  - '@tanstack/query-core@5.102.2'
+  - '@tanstack/react-query@5.102.2'

--- a/src/routes/dashboard/admin/members.tsx
+++ b/src/routes/dashboard/admin/members.tsx
@@ -69,7 +69,7 @@ export const Route = createFileRoute("/dashboard/admin/members")({
     sub: "Grant global roles and manage the chapter directory",
   },
   loader: async ({ context: { queryClient } }) =>
-    await queryClient.ensureQueryData(membersQueryOptions),
+    await queryClient.query({ ...membersQueryOptions, staleTime: "static" }),
 });
 
 /// Types and Interfaces

--- a/src/routes/dashboard/admin/overview.tsx
+++ b/src/routes/dashboard/admin/overview.tsx
@@ -20,10 +20,10 @@ export const Route = createFileRoute("/dashboard/admin/overview")({
     sub: "A brief overview of the chapter's members and data",
   },
   loader: async ({ context: { queryClient } }) => {
-    await queryClient.ensureQueryData(overviewMembersQueryOptions);
-    await queryClient.ensureQueryData(overviewProjectsQueryOptions);
-    await queryClient.ensureQueryData(overviewEventsQueryOptions);
-    await queryClient.ensureQueryData(overviewTagsQueryOptions);
+    await queryClient.query({ ...overviewMembersQueryOptions, staleTime: "static" });
+    await queryClient.query({ ...overviewProjectsQueryOptions, staleTime: "static" });
+    await queryClient.query({ ...overviewEventsQueryOptions, staleTime: "static" });
+    await queryClient.query({ ...overviewTagsQueryOptions, staleTime: "static" });
   },
 });
 

--- a/src/routes/dashboard/admin/tags.tsx
+++ b/src/routes/dashboard/admin/tags.tsx
@@ -70,7 +70,7 @@ export const Route = createFileRoute("/dashboard/admin/tags")({
     sub: "The shared taxonomy referenced by events and projects",
   },
   loader: async ({ context: { queryClient } }) =>
-    await queryClient.ensureQueryData(tagsQueryOptions),
+    await queryClient.query({ ...tagsQueryOptions, staleTime: "static" }),
 });
 
 /// Types and Interfaces

--- a/src/routes/dashboard/events.tsx
+++ b/src/routes/dashboard/events.tsx
@@ -38,10 +38,10 @@ export const Route = createFileRoute("/dashboard/events")({
   component: DashboardEvents,
   staticData: { area: "Member", title: "Events", sub: "Browse, RSVP, and check in" },
   loader: async ({ context: { queryClient } }) => {
-    await queryClient.prefetchQuery(eventsListQueryOptions);
-    await queryClient.prefetchQuery(meQueryOptions);
-    await queryClient.prefetchQuery(plannedEventsQueryOptions);
-    await queryClient.prefetchQuery(attendedEventsQueryOptions);
+    await queryClient.query(eventsListQueryOptions);
+    await queryClient.query(meQueryOptions);
+    await queryClient.query(plannedEventsQueryOptions);
+    await queryClient.query(attendedEventsQueryOptions);
   },
 });
 

--- a/src/routes/dashboard/events_.past.tsx
+++ b/src/routes/dashboard/events_.past.tsx
@@ -32,9 +32,9 @@ export const Route = createFileRoute("/dashboard/events_/past")({
   component: DashboardPastEvents,
   staticData: { area: "Member", title: "Past events", sub: "Your attendance history" },
   loader: async ({ context: { queryClient } }) => {
-    await queryClient.prefetchQuery(eventsListQueryOptions);
-    await queryClient.prefetchQuery(plannedEventsQueryOptions);
-    await queryClient.prefetchQuery(attendedEventsQueryOptions);
+    await queryClient.query(eventsListQueryOptions);
+    await queryClient.query(plannedEventsQueryOptions);
+    await queryClient.query(attendedEventsQueryOptions);
   },
 });
 

--- a/src/routes/dashboard/index.tsx
+++ b/src/routes/dashboard/index.tsx
@@ -48,10 +48,10 @@ export const Route = createFileRoute("/dashboard/")({
   component: DashboardHome,
   staticData: { area: "Member", title: "Dashboard", home: true },
   loader: async ({ context: { queryClient } }) => {
-    await queryClient.prefetchQuery(eventsListQueryOptions);
-    await queryClient.prefetchQuery(meQueryOptions);
-    await queryClient.prefetchQuery(plannedEventsQueryOptions);
-    await queryClient.prefetchQuery(attendedEventsQueryOptions);
+    await queryClient.query(eventsListQueryOptions);
+    await queryClient.query(meQueryOptions);
+    await queryClient.query(plannedEventsQueryOptions);
+    await queryClient.query(attendedEventsQueryOptions);
   },
 });
 

--- a/src/routes/dashboard/manage/events.tsx
+++ b/src/routes/dashboard/manage/events.tsx
@@ -89,8 +89,8 @@ export const Route = createFileRoute("/dashboard/manage/events")({
     sub: "Create, edit, and track attendance for chapter events",
   },
   loader: async ({ context: { queryClient } }) => {
-    await queryClient.prefetchQuery(manageEventsQueryOptions);
-    await queryClient.prefetchQuery(meQueryOptions);
+    await queryClient.query(manageEventsQueryOptions);
+    await queryClient.query(meQueryOptions);
   },
 });
 

--- a/src/routes/dashboard/manage/projects.tsx
+++ b/src/routes/dashboard/manage/projects.tsx
@@ -92,8 +92,8 @@ export const Route = createFileRoute("/dashboard/manage/projects")({
     sub: "Create, edit teams, and archive chapter projects",
   },
   loader: async ({ context: { queryClient } }) => {
-    await queryClient.prefetchQuery(manageProjectsQueryOptions({ name: "", page: 1 }));
-    await queryClient.prefetchQuery(manageInvitesQueryOptions);
+    await queryClient.query(manageProjectsQueryOptions({ name: "", page: 1 }));
+    await queryClient.query(manageInvitesQueryOptions);
   },
 });
 
@@ -759,9 +759,7 @@ function ManageProjectsPage() {
   const prefetchPage = useCallback(
     (next: number) => {
       queryClient
-        .prefetchQuery(
-          manageProjectsQueryOptions({ active: activeFilter, name: search, page: next }),
-        )
+        .query(manageProjectsQueryOptions({ active: activeFilter, name: search, page: next }))
         .catch(() => {});
     },
     [queryClient, activeFilter, search],

--- a/src/routes/dashboard/manage/projects_.$projectId.gallery.tsx
+++ b/src/routes/dashboard/manage/projects_.$projectId.gallery.tsx
@@ -44,8 +44,8 @@ export const Route = createFileRoute("/dashboard/manage/projects_/$projectId/gal
     sub: "Upload, reorder, and curate project media",
   },
   loader: async ({ context: { queryClient }, params: { projectId } }) => {
-    await queryClient.prefetchQuery(projectsQueryOptions);
-    await queryClient.prefetchQuery(projectMediaQueryOptions(projectId));
+    await queryClient.query(projectsQueryOptions);
+    await queryClient.query(projectMediaQueryOptions(projectId));
   },
 });
 

--- a/src/routes/dashboard/projects.tsx
+++ b/src/routes/dashboard/projects.tsx
@@ -55,9 +55,9 @@ export const Route = createFileRoute("/dashboard/projects")({
     sub: "Browse, join, and manage chapter projects",
   },
   loader: async ({ context: { queryClient } }) => {
-    await queryClient.prefetchQuery(projectsQueryOptions);
-    await queryClient.prefetchQuery(memberProjectsQueryOptions);
-    await queryClient.prefetchQuery(projectInvitesQueryOptions);
+    await queryClient.query(projectsQueryOptions);
+    await queryClient.query(memberProjectsQueryOptions);
+    await queryClient.query(projectInvitesQueryOptions);
   },
 });
 

--- a/src/routes/dashboard/route.tsx
+++ b/src/routes/dashboard/route.tsx
@@ -95,7 +95,7 @@ export const Route = createFileRoute("/dashboard")({
     settings: search.settings === "profile" ? "profile" : undefined,
   }),
   loader: async ({ context: { queryClient } }) => {
-    await queryClient.ensureQueryData(meQueryOptions).catch(() => {
+    await queryClient.query({ ...meQueryOptions, staleTime: "static" }).catch(() => {
       redirect({ to: "/login", search: {}, throw: true });
     });
   },

--- a/src/routes/event/$eventId.tsx
+++ b/src/routes/event/$eventId.tsx
@@ -22,8 +22,9 @@ import { type FullEvents } from "@/types/kanae.gen";
 
 export const Route = createFileRoute("/event/$eventId")({
   component: Event,
-  loader: ({ context: { queryClient }, params: { eventId } }) =>
-    queryClient.prefetchQuery(eventDetailQueryOptions(eventId)),
+  loader: async ({ context: { queryClient }, params: { eventId } }) => {
+    await queryClient.query(eventDetailQueryOptions(eventId)).catch(() => {});
+  },
 });
 
 /// Types and Interfaces

--- a/src/routes/events.tsx
+++ b/src/routes/events.tsx
@@ -18,7 +18,9 @@ import { type KanaePage } from "@/types/pages";
 
 export const Route = createFileRoute("/events")({
   component: Events,
-  loader: ({ context: { queryClient } }) => queryClient.prefetchQuery(eventsQueryOptions),
+  loader: async ({ context: { queryClient } }) => {
+    await queryClient.query(eventsQueryOptions).catch(() => {});
+  },
 });
 
 /// Types and Interfaces

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -27,7 +27,9 @@ import { type KanaePage } from "@/types/pages";
 
 export const Route = createFileRoute("/")({
   component: Index,
-  loader: ({ context: { queryClient } }) => queryClient.prefetchQuery(eventsQueryOptions),
+  loader: async ({ context: { queryClient } }) => {
+    await queryClient.query(eventsQueryOptions).catch(() => {});
+  },
 });
 
 /// Interfaces & Types

--- a/src/routes/project/$projectId.tsx
+++ b/src/routes/project/$projectId.tsx
@@ -22,7 +22,7 @@ import { type MediaRecord, type ProjectDetails } from "@/types/kanae.gen";
 export const Route = createFileRoute("/project/$projectId")({
   component: Project,
   loader: async ({ context: { queryClient }, params: { projectId } }) => {
-    await queryClient.ensureQueryData(projectDetailQueryOptions(projectId));
+    await queryClient.query({ ...projectDetailQueryOptions(projectId), staleTime: "static" });
   },
 });
 

--- a/src/routes/projects.tsx
+++ b/src/routes/projects.tsx
@@ -22,7 +22,9 @@ import { type KanaePage } from "@/types/pages";
 
 export const Route = createFileRoute("/projects")({
   component: Projects,
-  loader: ({ context: { queryClient } }) => queryClient.prefetchQuery(projectsQueryOptions),
+  loader: async ({ context: { queryClient } }) => {
+    await queryClient.query(projectsQueryOptions).catch(() => {});
+  },
 });
 
 /// Types and Interfaces


### PR DESCRIPTION
# Summary

Tanstack Query v5.102.0 deprecated the usages of `fetchQuery`, `prefetchQuery`, and `ensureQueryData` to favor a [unified `queryClient.query()` method](<https://github.com/TanStack/query/pull/10658>) to ease confusion and usages. More details about this unification can be found [within the RFC](<https://github.com/TanStack/query/discussions/9135>) on their proposal.

We heavily utilize Tanstack Query for all of our data fetching needs, so quite the migration was needed. Ultimately based off of the RFC, we can see a general before/after of our utilizations of the old methods vs the new unified versions:

| before | after |
| --- | --- |
| `prefetchQuery(options)` | `query(options)`, plus `.catch(() => {})` where the old error swallowing mattered |
| `ensureQueryData(options)` | `query({ ...options, staleTime: "static" })` |

`staleTime: "static"` is an exact match for the old `ensureQueryData` semantics: `isStaleByTime` returns `false` for `'static'` whenever data exists, so a cached read never refetches, same as the old cached-data early return. This is also cited within the RFC as the official migration path for `ensureQueryData`.

In terms of behavior, it should match the previous behaviors before this migration without any issue or major changes. So behavior-wise, it's just the exact same as before.

## Types of changes

What types of changes does your code introduce to the UC Merced's ACM Chapter Website?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
