### PR TITLE
Trust pnpm lockfile in `Dockerfile`

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,7 @@ RUN ln -s /opt/pnpm/bin/pnpm /usr/local/bin/pnpm
 # Install dependencies first (cached unless manifests change)
 COPY package.json pnpm-lock.yaml /website/
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
-    pnpm install --frozen-lockfile --ignore-scripts
+    pnpm install --frozen-lockfile --trust-lockfile --ignore-scripts
 
 # Copy necessary build configurations
 COPY vite.config.ts index.html tsconfig.json tsconfig.app.json tsconfig.node.json docker/nginx.conf /website/


### PR DESCRIPTION
# Summary

We generally already trust it within our `pnpm-workspace.yaml`, as we know that we ourselves manages it when nesscary, and renovate has it configured where it will only pull in updates for packages with versions that are older than 1 day (which is pnpm's default).

## Types of changes

What types of changes does your code introduce to the UC Merced's ACM Chapter Website?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
