### PR TITLE
Allow access to Kanae and Kratos via reverse proxy

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,6 +25,12 @@ COPY vite.config.ts index.html tsconfig.json tsconfig.app.json tsconfig.node.jso
 COPY public /website/public
 COPY src /website/src
 
+ARG VITE_API_URL=/api
+ARG VITE_ORY_URL=/auth
+
+ENV VITE_API_URL=$VITE_API_URL
+ENV VITE_ORY_URL=$VITE_ORY_URL
+
 # Now build for optimal caching
 RUN pnpm run build
 

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -18,6 +18,8 @@ server {
   server_tokens off;
   absolute_redirect off;
 
+  resolver 127.0.0.11 ipv6=off valid=10s;
+
   gzip on;
   gzip_vary on;
   gzip_comp_level 6;
@@ -38,6 +40,47 @@ server {
 
   location ^~ /assets/ {
     try_files $uri =404;
+  }
+
+  location /auth/ {
+    set $up_kratos http://kratos:4433;
+    rewrite ^/auth/(.*)$ /$1 break;
+    proxy_pass $up_kratos;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_hide_header Cache-Control;
+    add_header Cache-Control $upstream_http_cache_control always;
+  }
+
+  location /api/ {
+    set $up_kanae http://kanae:8000;
+    rewrite ^/api/(.*)$ /$1 break;
+    proxy_pass $up_kanae;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_hide_header Cache-Control;
+    add_header Cache-Control $upstream_http_cache_control always;
+  }
+
+  location ~ ^/(kanae-media|kanae-public)/ {
+    set $up_garage http://garage:3900;
+    proxy_pass $up_garage;
+    proxy_set_header Host $http_host;
+    client_max_body_size 0;
+    proxy_request_buffering off;
+    proxy_hide_header Cache-Control;
+    add_header Cache-Control $upstream_http_cache_control always;
+  }
+
+  location /public/ {
+    set $up_garage_web http://garage:3902;
+    rewrite ^/public/(.*)$ /$1 break;
+    proxy_pass $up_garage_web;
+    proxy_set_header Host kanae-public.web.garage.localhost;
+    proxy_hide_header Cache-Control;
+    add_header Cache-Control $upstream_http_cache_control always;
   }
 
   location / {


### PR DESCRIPTION
# Summary

Normally, if you run the full web stack together on a laptop, it works just fine. But via tailscale to look at it via mobile, and it fails. The idea is to basically rewrite our links to instead use paths on the nginx server that reverse proxies the traffic to the correct service. That way, you can access it regardless of platform if you run on Tailscale.

## Types of changes

What types of changes does your code introduce to the UC Merced's ACM Chapter Website?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
